### PR TITLE
[feat] React Native SDK 개발에 필요한 메소드 구현

### DIFF
--- a/BluxClient.podspec
+++ b/BluxClient.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'BluxClient'
-  s.version          = '0.2.0'
+  s.version          = '0.2.1'
   s.summary          = 'Blux iOS SDK.'
 
   s.homepage         = 'https://github.com/zaikorea/Blux-iOS-SDK.git'

--- a/BluxClient/Classes/BluxClient.swift
+++ b/BluxClient/Classes/BluxClient.swift
@@ -69,9 +69,8 @@ import UIKit
         
         DeviceService.update(body: body)
     }
-    
-    /// Send Request
-    public static func sendRequest(_ request: EventRequest) {
+
+    public static func sendRequestData(_ data: [Event]) {
         guard let deviceId = SdkConfig.deviceIdInUserDefaults else {
             return
         }
@@ -79,14 +78,20 @@ import UIKit
             return
         }
         
-        let requestData = request.getPayload()
-        requestData.forEach { event in
+        data.forEach { event in
             event.bluxId = bluxId
             event.deviceId = deviceId
             event.userId = SdkConfig.userIdInUserDefaults
         }
         
-        EventService.sendRequest(requestData)
+        EventService.sendRequest(data)
+    }
+    
+    
+    /// Send Request
+    public static func sendRequest(_ request: EventRequest) {
+        let requestData = request.getPayload()
+        self.sendRequestData(requestData)
     }
 
     private static func deviceCreateOrActivate(_ requestPermissionOnLaunch: Bool) {

--- a/BluxClient/Classes/BluxClient.swift
+++ b/BluxClient/Classes/BluxClient.swift
@@ -88,8 +88,8 @@ import UIKit
         
         EventService.sendRequest(requestData)
     }
-    
-    public static func deviceCreateOrActivate(_ requestPermissionOnLaunch: Bool) {
+
+    private static func deviceCreateOrActivate(_ requestPermissionOnLaunch: Bool) {
         if isActivated { return }
         isActivated = true
         

--- a/BluxClient/Classes/BluxNotification.swift
+++ b/BluxClient/Classes/BluxNotification.swift
@@ -98,4 +98,21 @@ import Foundation
         
         return bluxNotification
     }
+
+    public func toDictionary() -> [String: Optional<Any>] {
+        let dict: [String: Optional<Any>] = [
+            "id": id,
+            "customerEngagementType": customerEngagementType,
+            "customerEngagementId": customerEngagementId,
+            "customerEngagementTaskId": customerEngagementTaskId,
+            "body": body,
+            "title": title,
+            "url": url,
+            "imageUrl": imageUrl,
+            "data": data
+        ]
+    
+        return dict
+  }
+
 }

--- a/BluxClient/Classes/SdkConfig.swift
+++ b/BluxClient/Classes/SdkConfig.swift
@@ -14,7 +14,7 @@ public enum SdkType: String {
 }
 
 final class SdkConfig {
-    static var sdkVersion = "0.2.0"
+    static var sdkVersion = "0.2.1"
     static var sdkType: SdkType = .native
     static var bluxSuiteName = "group.ai.blux.app"
     

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - BluxClient (0.2.0)
+  - BluxClient (0.2.1)
 
 DEPENDENCIES:
   - BluxClient (from `../`)
@@ -9,7 +9,7 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  BluxClient: 9b4c6396147495d2d760a2b9f4ba492f72c7f70a
+  BluxClient: 20f373b704afe7bfb3b6047f2c463701308b401f
 
 PODFILE CHECKSUM: b54f9e37f506b738b4b50216c6e5eab039280f5c
 

--- a/Example/Pods/Local Podspecs/BluxClient.podspec.json
+++ b/Example/Pods/Local Podspecs/BluxClient.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "BluxClient",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "summary": "Blux iOS SDK.",
   "homepage": "https://github.com/zaikorea/Blux-iOS-SDK.git",
   "license": {
@@ -12,7 +12,7 @@
   },
   "source": {
     "git": "https://github.com/zaikorea/Blux-iOS-SDK.git",
-    "tag": "0.2.0"
+    "tag": "0.2.1"
   },
   "platforms": {
     "ios": "13.0"

--- a/Example/Pods/Manifest.lock
+++ b/Example/Pods/Manifest.lock
@@ -1,5 +1,5 @@
 PODS:
-  - BluxClient (0.2.0)
+  - BluxClient (0.2.1)
 
 DEPENDENCIES:
   - BluxClient (from `../`)
@@ -9,7 +9,7 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  BluxClient: 9b4c6396147495d2d760a2b9f4ba492f72c7f70a
+  BluxClient: 20f373b704afe7bfb3b6047f2c463701308b401f
 
 PODFILE CHECKSUM: b54f9e37f506b738b4b50216c6e5eab039280f5c
 

--- a/Example/Pods/Target Support Files/BluxClient/BluxClient-Info.plist
+++ b/Example/Pods/Target Support Files/BluxClient/BluxClient-Info.plist
@@ -15,7 +15,7 @@
   <key>CFBundlePackageType</key>
   <string>FMWK</string>
   <key>CFBundleShortVersionString</key>
-  <string>0.2.0</string>
+  <string>0.2.1</string>
   <key>CFBundleSignature</key>
   <string>????</string>
   <key>CFBundleVersion</key>


### PR DESCRIPTION
- BluxNotification class에서 toDictionary 메소드를 만들었습니다. javascript의 callback에서 데이터를 넘기는데 사용됩니다.
- 불필요하게 public으로 노출되고 있던 메소드를 private로 변경했습니다.
- RN에서는 Swift의 Request Class를 만들지 못하므로 임의의 object를 넣을 수 있게 하기 위해 sendRequestData부분을 따로 뺐습니다.
- 위 변경사항 반영하여 0.2.1로 배포합니다. (이미함)