### PR TITLE
Refactor: initialize할 때 실패하더라도 알려주기

### DIFF
--- a/BluxClient.podspec
+++ b/BluxClient.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'BluxClient'
-  s.version          = '0.3.2'
+  s.version          = '0.3.3'
   s.summary          = 'Blux iOS SDK.'
 
   s.homepage         = 'https://github.com/zaikorea/Blux-iOS-SDK.git'

--- a/BluxClient.podspec
+++ b/BluxClient.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'BluxClient'
-  s.version          = '0.3.1'
+  s.version          = '0.3.2'
   s.summary          = 'Blux iOS SDK.'
 
   s.homepage         = 'https://github.com/zaikorea/Blux-iOS-SDK.git'

--- a/BluxClient/Classes/BluxClient.swift
+++ b/BluxClient/Classes/BluxClient.swift
@@ -97,12 +97,15 @@ struct PropertiesWrapper<T: Codable>: Codable {
     }
 
     /// Set userId of the device
-    @objc public static func signIn(userId: String) {
+    @objc public static func signIn(userId: String, completion: @escaping ((NSError?) -> Void) = { _ in }) {
         guard
             let clientId = SdkConfig.clientIdInUserDefaults,
             let bluxId = SdkConfig.bluxIdInUserDefaults,
             let deviceId = SdkConfig.deviceIdInUserDefaults
-        else { return }
+        else {
+            completion(NSError(domain: "BluxClient", code: -1, userInfo: [NSLocalizedDescriptionKey: "Required IDs not found"]))
+            return
+        }
 
         let body = DeviceService.getBluxDeviceInfo()
         body.userId = userId
@@ -114,6 +117,7 @@ struct PropertiesWrapper<T: Codable>: Codable {
         ) { (response: BluxDeviceResponse?, error) in
             if let error = error {
                 Logger.error("Failed to request sign-in. - \(error)")
+                completion(NSError(domain: "BluxClient", code: -1, userInfo: [NSLocalizedDescriptionKey: "Failed to request sign-in. - \(error)"]))
                 return
             }
 
@@ -122,6 +126,7 @@ struct PropertiesWrapper<T: Codable>: Codable {
                 SdkConfig.userIdInUserDefaults = userId
                 Logger.verbose("Signin request success.")
                 Logger.verbose("Blux ID: \(bluxDeviceResponse.bluxId).")
+                completion(nil)
             }
         }
     }

--- a/BluxClient/Classes/SdkConfig.swift
+++ b/BluxClient/Classes/SdkConfig.swift
@@ -14,7 +14,7 @@ public enum SdkType: String {
 }
 
 final class SdkConfig {
-    static var sdkVersion = "0.3.2"
+    static var sdkVersion = "0.3.3"
     static var sdkType: SdkType = .native
     
     static var bluxAppGroupNameKey = "BluxAppGroupName"

--- a/BluxClient/Classes/SdkConfig.swift
+++ b/BluxClient/Classes/SdkConfig.swift
@@ -14,7 +14,7 @@ public enum SdkType: String {
 }
 
 final class SdkConfig {
-    static var sdkVersion = "0.3.1"
+    static var sdkVersion = "0.3.2"
     static var sdkType: SdkType = .native
     
     static var bluxAppGroupNameKey = "BluxAppGroupName"

--- a/Example/BluxClient/AppDelegate.swift
+++ b/Example/BluxClient/AppDelegate.swift
@@ -6,66 +6,93 @@
 //  Copyright (c) 2024 dongjoocha. All rights reserved.
 //
 
-import UIKit
 import BluxClient
+import UIKit
 
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate {
-    
     var window: UIWindow?
-    
+
 //    let clientId = "CLIENT ID"
 //    let apiKey = "SECRET KEY"
   
     let clientId = "637a1627"
     let apiKey = "0QwVM7OdHcP1JlUm34acWQLTXnLLpInEncy3PT2QvtE"
-    
-    func application(_ application: UIApplication,
-                     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
-        
-        BluxClient.initialize(launchOptions, bluxClientId: clientId, bluxAPIKey: apiKey) {
-            BluxClient.signIn(userId: "luna")
+    func application(
+        _ application: UIApplication,
+        didFinishLaunchingWithOptions launchOptions: [UIApplication
+            .LaunchOptionsKey: Any]?
+    ) -> Bool {
+        BluxClient.setAPIStage("stg")
+
+        BluxClient.initialize(launchOptions, bluxClientId: clientId, bluxAPIKey: apiKey, requestPermissionOnLaunch: true) { error in
+            if let error = error {
+                Logger.verbose("BluxClient.initialize error: \(error)")
+            } else {
+                Logger.verbose("BluxClient.initialize success")
+                BluxClient.signIn(userId: "luna")
+            }
         }
-        
+
         // Swizzling Disabled
-         UNUserNotificationCenter.current().delegate = self
-    
+        UNUserNotificationCenter.current().delegate = self
+
         return true
     }
-    
+
     // Example Deeplink configuration
-//    func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey : Any] = [:]) -> Bool {
-//
-//        let urlComponents = URLComponents(url: url, resolvingAgainstBaseURL: false)
-//        let host = urlComponents?.host
-//        let path = urlComponents?.path
-//
-//        if host == "product", let productId = path?.components(separatedBy: "/").last {
-//            appState.selectedTab = .home
-//            appState.selectedProductId = productId
-//        } else if host == "tab", let tabIndexString = path?.components(separatedBy: "/").last, let tabIndex = Int(tabIndexString) {
-//            if let tab = AppState.Tab(rawValue: tabIndex) {
-//                appState.selectedTab = tab
-//            }
-//        } else {
-//            return false
-//        }
-//
-//        return true
-//    }
-    
+    //    func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey : Any] = [:]) -> Bool {
+    //
+    //        let urlComponents = URLComponents(url: url, resolvingAgainstBaseURL: false)
+    //        let host = urlComponents?.host
+    //        let path = urlComponents?.path
+    //
+    //        if host == "product", let productId = path?.components(separatedBy: "/").last {
+    //            appState.selectedTab = .home
+    //            appState.selectedProductId = productId
+    //        } else if host == "tab", let tabIndexString = path?.components(separatedBy: "/").last, let tabIndex = Int(tabIndexString) {
+    //            if let tab = AppState.Tab(rawValue: tabIndex) {
+    //                appState.selectedTab = tab
+    //            }
+    //        } else {
+    //            return false
+    //        }
+    //
+    //        return true
+    //    }
+
     // Swizzling Disabled
-     func application(_ application: UIApplication, didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {
-         BluxAppDelegate.shared.application(application, didRegisterForRemoteNotificationsWithDeviceToken: deviceToken)
-     }
+    func application(
+        _ application: UIApplication,
+        didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data
+    ) {
+        BluxAppDelegate.shared.application(
+            application,
+            didRegisterForRemoteNotificationsWithDeviceToken: deviceToken)
+    }
 }
 
 // Swizzling Disabled
- extension AppDelegate: UNUserNotificationCenterDelegate {
-   func userNotificationCenter(_ center: UNUserNotificationCenter, didReceive response: UNNotificationResponse, withCompletionHandler completionHandler: @escaping () -> Void) {
-       BluxNotificationCenter.shared.userNotificationCenter(center, didReceive: response, withCompletionHandler: completionHandler)
-   }
-   func userNotificationCenter(_ center: UNUserNotificationCenter, willPresent notification: UNNotification, withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void) {
-       BluxNotificationCenter.shared.userNotificationCenter(center, willPresent: notification, withCompletionHandler: completionHandler)
-   }
- }
+extension AppDelegate: UNUserNotificationCenterDelegate {
+    func userNotificationCenter(
+        _ center: UNUserNotificationCenter,
+        didReceive response: UNNotificationResponse,
+        withCompletionHandler completionHandler: @escaping () -> Void
+    ) {
+        BluxNotificationCenter.shared.userNotificationCenter(
+            center, didReceive: response,
+            withCompletionHandler: completionHandler)
+    }
+
+    func userNotificationCenter(
+        _ center: UNUserNotificationCenter,
+        willPresent notification: UNNotification,
+        withCompletionHandler completionHandler: @escaping (
+            UNNotificationPresentationOptions
+        ) -> Void
+    ) {
+        BluxNotificationCenter.shared.userNotificationCenter(
+            center, willPresent: notification,
+            withCompletionHandler: completionHandler)
+    }
+}

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - BluxClient (0.3.1)
+  - BluxClient (0.3.2)
 
 DEPENDENCIES:
   - BluxClient (from `../`)

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - BluxClient (0.3.2)
+  - BluxClient (0.3.3)
 
 DEPENDENCIES:
   - BluxClient (from `../`)

--- a/Example/Pods/Local Podspecs/BluxClient.podspec.json
+++ b/Example/Pods/Local Podspecs/BluxClient.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "BluxClient",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "summary": "Blux iOS SDK.",
   "homepage": "https://github.com/zaikorea/Blux-iOS-SDK.git",
   "license": {
@@ -12,7 +12,7 @@
   },
   "source": {
     "git": "https://github.com/zaikorea/Blux-iOS-SDK.git",
-    "tag": "0.3.2"
+    "tag": "0.3.3"
   },
   "platforms": {
     "ios": "14.0"

--- a/Example/Pods/Local Podspecs/BluxClient.podspec.json
+++ b/Example/Pods/Local Podspecs/BluxClient.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "BluxClient",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "summary": "Blux iOS SDK.",
   "homepage": "https://github.com/zaikorea/Blux-iOS-SDK.git",
   "license": {
@@ -12,7 +12,7 @@
   },
   "source": {
     "git": "https://github.com/zaikorea/Blux-iOS-SDK.git",
-    "tag": "0.3.1"
+    "tag": "0.3.2"
   },
   "platforms": {
     "ios": "14.0"

--- a/Example/Pods/Manifest.lock
+++ b/Example/Pods/Manifest.lock
@@ -1,5 +1,5 @@
 PODS:
-  - BluxClient (0.3.1)
+  - BluxClient (0.3.2)
 
 DEPENDENCIES:
   - BluxClient (from `../`)

--- a/Example/Pods/Manifest.lock
+++ b/Example/Pods/Manifest.lock
@@ -1,5 +1,5 @@
 PODS:
-  - BluxClient (0.3.2)
+  - BluxClient (0.3.3)
 
 DEPENDENCIES:
   - BluxClient (from `../`)

--- a/Example/Pods/Target Support Files/BluxClient/BluxClient-Info.plist
+++ b/Example/Pods/Target Support Files/BluxClient/BluxClient-Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.3.1</string>
+	<string>0.3.2</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/Example/Pods/Target Support Files/BluxClient/BluxClient-Info.plist
+++ b/Example/Pods/Target Support Files/BluxClient/BluxClient-Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.3.2</string>
+	<string>0.3.3</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/README.md
+++ b/README.md
@@ -18,13 +18,13 @@ use_frameworks!
 
 target 'YOUR_PROJECT_NAME' do
   // 아래 줄 추가
-  pod 'BluxClient', '0.3.1'  
+  pod 'BluxClient', '0.3.2'  
 end
 
 // 파일 최하단의 아래 줄 추가
 // 앞서 입력한 Extension의 Product Name을 target 이름으로 설정합니다.
 target 'BluxNotificationServiceExtenstion' do
-  pod 'BluxClient', '0.3.1'
+  pod 'BluxClient', '0.3.2'
 end
 ```
 

--- a/README.md
+++ b/README.md
@@ -39,8 +39,12 @@ end
 
 ```swift
 BluxClient.setLogLevel()
-BluxClient.initialize(launchOptions, bluxClientId: BLUX_CLIENT_ID, bluxAPIKey: BLUX_API_KEY) {
+BluxClient.initialize(launchOptions, bluxClientId: BLUX_CLIENT_ID, bluxAPIKey: BLUX_API_KEY) { error in
+  if let error = error {
+    print("BluxClient initialize error: \(error)")
+  } else {
     BluxClient.signIn(userId: "USER_ID")
+  }
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -18,13 +18,13 @@ use_frameworks!
 
 target 'YOUR_PROJECT_NAME' do
   // 아래 줄 추가
-  pod 'BluxClient', '0.3.2'  
+  pod 'BluxClient', '0.3.3'  
 end
 
 // 파일 최하단의 아래 줄 추가
 // 앞서 입력한 Extension의 Product Name을 target 이름으로 설정합니다.
 target 'BluxNotificationServiceExtenstion' do
-  pod 'BluxClient', '0.3.2'
+  pod 'BluxClient', '0.3.3'
 end
 ```
 


### PR DESCRIPTION
- 기반 설명
initialize는 completion callback을 바탕으로 성공하게 되면 함수를 실행하는데, 이 때 sign을 하거나 다른 처리를 같이 하게 됩니다.

- 문제 상황
RN SDK와 flutter SDK가 현재는 실패에 대한 정보를 알 수가 없어서, SDK단에서 몇 초 이상 걸리면 실패로 간주하게 만드는 처리를 직접 해야 하는 상황입니다.

- 변경 내용
에러에 대한 처리를 할 수 있도록 (NSError?) -> Void 형태로 completion 함수가 항상 실행되도록 변경했습니다.