### PR TITLE
0.4.5

### DIFF
--- a/BluxClient.podspec
+++ b/BluxClient.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'BluxClient'
-  s.version          = '0.4.4'
+  s.version          = '0.4.5'
   s.summary          = 'Blux iOS SDK.'
 
   s.homepage         = 'https://github.com/zaikorea/Blux-iOS-SDK.git'

--- a/BluxClient/Classes/BluxAppDelegate.swift
+++ b/BluxClient/Classes/BluxAppDelegate.swift
@@ -13,51 +13,6 @@ import UIKit
     
     @objc public static let shared = BluxAppDelegate()
     
-    func swizzle() {
-        guard !SdkConfig.isSwizzled else {
-            Logger.error("Already swizzled.")
-            return
-        }
-        
-        Logger.verbose("Start swizzling UIApplicationDelegate methods.")
-        swizzleMethod(
-            originalSelector: #selector(UIApplicationDelegate.application(_:didRegisterForRemoteNotificationsWithDeviceToken:)),
-            swizzledSelector: #selector(self.application(_:didRegisterForRemoteNotificationsWithDeviceToken:)),
-            in: UIApplication.shared.delegate
-        )
-        SdkConfig.isSwizzled = true
-        Logger.verbose("Swizzling success.")
-    }
-    
-    // MARK: - Swizzler
-    
-    private func swizzleMethod(originalSelector: Selector, swizzledSelector: Selector, in delegate: UIApplicationDelegate?) {
-        guard let delegateClass = object_getClass(delegate) else {
-            Logger.error("Failed to get delegate class.")
-            return
-        }
-        
-        guard let swizzledMethod = class_getInstanceMethod(BluxAppDelegate.self, swizzledSelector) else {
-            Logger.error("Failed to get swizzled method for \(swizzledSelector).")
-            return
-        }
-        
-        if let originalMethod = class_getInstanceMethod(delegateClass, originalSelector) {
-            method_exchangeImplementations(originalMethod, swizzledMethod)
-            Logger.verbose("Exchanged \(originalSelector) with \(swizzledSelector).")
-        } else {
-            let typeEncoding = method_getTypeEncoding(swizzledMethod)
-            let didAddMethod = class_addMethod(delegateClass, originalSelector, method_getImplementation(swizzledMethod), typeEncoding)
-            if didAddMethod {
-                Logger.verbose("Added \(originalSelector) and set to \(swizzledSelector).")
-            } else {
-                Logger.error("Failed to add method for \(originalSelector).")
-            }
-        }
-    }
-    
-    // MARK: - Swizzle Methods
-    
     @objc public func application(
         _ application: UIApplication,
         didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data

--- a/BluxClient/Classes/BluxClient.swift
+++ b/BluxClient/Classes/BluxClient.swift
@@ -14,9 +14,6 @@ struct PropertiesWrapper<T: Codable>: Codable {
 @objc open class BluxClient: NSObject {
     private static var isActivated: Bool = false
     private static var appDelegate = BluxAppDelegate()
-    private static let swizzlingEnabledKey = "BluxSwizzlingEnabled"
-
-    // MARK: - Public Methods
 
     /// Initialize Blux SDK
     @objc public static func initialize(
@@ -47,15 +44,6 @@ struct PropertiesWrapper<T: Codable>: Codable {
 
         ColdStartNotificationManager.setColdStartNotification(
             launchOptions: launchOptions)
-
-        let swizzlingEnabled =
-            Bundle.main.object(forInfoDictionaryKey: swizzlingEnabledKey)
-                as? Bool
-        if swizzlingEnabled != false {
-            UNUserNotificationCenter.current().delegate =
-                BluxNotificationCenter.shared
-            appDelegate.swizzle()
-        }
 
         ColdStartNotificationManager.process()
 
@@ -352,8 +340,6 @@ struct PropertiesWrapper<T: Codable>: Codable {
             }
         }
     }
-
-    // MARK: Private Methods
 
     private static func requestPermissionForNotifications() {
         let options: UNAuthorizationOptions = [.badge, .alert, .sound]

--- a/BluxClient/Classes/BluxNotificationCenter.swift
+++ b/BluxClient/Classes/BluxNotificationCenter.swift
@@ -129,7 +129,7 @@ public class BluxNotificationCenter: NSObject, UNUserNotificationCenterDelegate 
             navigationController, animated: true, completion: nil)
     }
 
-    private func getTopViewController(_ baseViewController: UIViewController? = UIApplication.shared.keyWindow?.rootViewController) -> UIViewController? {
+    private func getTopViewController(_ baseViewController: UIViewController? = UIApplication.shared.windows.first(where: { $0.isKeyWindow } )?.rootViewController) -> UIViewController? {
         if let navigationController = baseViewController as? UINavigationController {
             return getTopViewController(navigationController.visibleViewController)
         }

--- a/BluxClient/Classes/BluxNotificationCenter.swift
+++ b/BluxClient/Classes/BluxNotificationCenter.swift
@@ -12,15 +12,13 @@ import UserNotifications
 public class BluxNotificationCenter: NSObject, UNUserNotificationCenterDelegate {
     @objc public static let shared = BluxNotificationCenter()
 
-    // MARK: - Delegate Methods
-
     /// Called when notification is clicked
     @objc public func userNotificationCenter(
         _ center: UNUserNotificationCenter,
         didReceive response: UNNotificationResponse,
         withCompletionHandler completionHandler: @escaping () -> Void
     ) {
-        defer { // Called just before the function terminates
+        defer { // Called just before the function terminatesg
             completionHandler()
         }
 
@@ -62,6 +60,8 @@ public class BluxNotificationCenter: NSObject, UNUserNotificationCenterDelegate 
                 )
                 return
             }
+            
+            
 
             if let urlString = notification.url,
                let url = URL(string: urlString), let scheme = url.scheme
@@ -113,8 +113,6 @@ public class BluxNotificationCenter: NSObject, UNUserNotificationCenterDelegate 
             }
         }
     }
-
-    // MARK: Private Methods
 
     private func presentWebView(url: URL) {
         guard let topViewController = getTopViewController() else {

--- a/BluxClient/Classes/DeviceService.swift
+++ b/BluxClient/Classes/DeviceService.swift
@@ -28,10 +28,6 @@ enum DeviceService {
         )
     }
 
-    /// Create device data
-    /// - Parameters:
-    ///   - body: Data key & value
-
     static func initializeDevice(
         deviceId: String?,
         completion: @escaping (Result<BluxDeviceResponse, Error>) -> Void = { _ in }

--- a/BluxClient/Classes/NotificationReceivedEvent.swift
+++ b/BluxClient/Classes/NotificationReceivedEvent.swift
@@ -21,7 +21,5 @@ import Foundation
     @objc public func display() {
         Logger.verbose("Notification received: \(self.notification)")
         self.completionHandler([.alert, .sound])
-
-        EventService.createReceived(self.notification.id)
     }
 }

--- a/BluxClient/Classes/SdkConfig.swift
+++ b/BluxClient/Classes/SdkConfig.swift
@@ -14,7 +14,7 @@ public enum SdkType: String {
 }
 
 final class SdkConfig {
-    static var sdkVersion = "0.4.4"
+    static var sdkVersion = "0.4.5"
     static var sdkType: SdkType = .native
     
     static var bluxAppGroupNameKey = "BluxAppGroupName"
@@ -28,7 +28,6 @@ final class SdkConfig {
 
     static var logLevel: LogLevel = .verbose
     static var requestPermissionOnLaunch: Bool = false
-    static var isSwizzled: Bool = false
     
     /// Save bluxId in user defaults (local storage)
     private static var bluxIdKey = "bluxId"

--- a/Example/BluxClient/AppDelegate.swift
+++ b/Example/BluxClient/AppDelegate.swift
@@ -13,15 +13,15 @@ import UIKit
 class AppDelegate: UIResponder, UIApplicationDelegate {
     var window: UIWindow?
 
-    let applicationId = "66a38b6a233aab065644296f"
-    let apiKey = "0QwVM7OdHcP1JlUm34acWQLTXnLLpInEncy3PT2QvtE"
+    let applicationId = "66fac6b03e71e06835703c25"
+    let apiKey = "Is5r2sK-HBQe4sX343twQopcccevFm0Ci6nu9tA9"
     
     func application(
         _ application: UIApplication,
         didFinishLaunchingWithOptions launchOptions: [UIApplication
             .LaunchOptionsKey: Any]?
     ) -> Bool {
-        BluxClient.setAPIStage("stg")
+        BluxClient.setAPIStage("prod")
 
         BluxClient.initialize(launchOptions, bluxApplicationId: applicationId, bluxAPIKey: apiKey, requestPermissionOnLaunch: true) { error in
             if let error = error {

--- a/Example/BluxClient/Info.plist
+++ b/Example/BluxClient/Info.plist
@@ -4,8 +4,6 @@
 <dict>
 	<key>BluxAppGroupName</key>
 	<string>group.com.zaikorea.BluxExample</string>
-	<key>BluxSwizzlingEnabled</key>
-	<false/>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleExecutable</key>
@@ -39,6 +37,10 @@
 	<string></string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>remote-notification</string>
+	</array>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIMainStoryboardFile</key>

--- a/Example/BluxNotificationServiceExtenstion/NotificationService.swift
+++ b/Example/BluxNotificationServiceExtenstion/NotificationService.swift
@@ -8,8 +8,6 @@
 
 import BluxClient
 
-//class NotificationService: BluxNotificationServiceExtension {}
-
 // Swizzling Disabled
  class NotificationService: UNNotificationServiceExtension {
      override func didReceive(_ request: UNNotificationRequest, withContentHandler contentHandler: @escaping (UNNotificationContent) -> Void) {

--- a/Example/Pods/Target Support Files/BluxClient/BluxClient-Info.plist
+++ b/Example/Pods/Target Support Files/BluxClient/BluxClient-Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.4.4</string>
+	<string>0.4.5</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/README.md
+++ b/README.md
@@ -18,13 +18,13 @@ use_frameworks!
 
 target 'YOUR_PROJECT_NAME' do
   // 아래 줄 추가
-  pod 'BluxClient', '0.4.4'
+  pod 'BluxClient', '0.4.5'
 end
 
 // 파일 최하단의 아래 줄 추가
 // 앞서 입력한 Extension의 Product Name을 target 이름으로 설정합니다.
 target 'BluxNotificationServiceExtenstion' do
-  pod 'BluxClient', '0.4.4'
+  pod 'BluxClient', '0.4.5'
 end
 ```
 


### PR DESCRIPTION
- Swizzling을 기본적으로 비활성화하도록 변경했습니다.
- keyWindow가 iOS 13부터 deprecated됨에 따라, iOS 버전에 관계없이 안전하게 동작하도록 방식 개선했습니다.