### PR TITLE
feat: 5초마다 한 번씩 인앱메시지 데이터 폴링

### DIFF
--- a/BluxClient/Classes/BluxClient.swift
+++ b/BluxClient/Classes/BluxClient.swift
@@ -66,6 +66,8 @@ struct PropertiesWrapper<T: Codable>: Codable {
                 let eventRequest = EventRequest()
                 eventRequest.events.append(Event(eventType: "visit"))
                 self.sendEvent(eventRequest)
+                // Enable in-app auto dispatch control after Blux user creation
+                InappService.enableAutoDispatching()
 
                 completion(nil)
                 if requestPermissionOnLaunch {
@@ -277,7 +279,6 @@ struct PropertiesWrapper<T: Codable>: Codable {
 
     public static func sendEventData(_ events: [Event]) {
         EventService.sendEvent(events)
-//        InappService.handleInappEvent(events)
     }
 
     /// Send Request

--- a/BluxClient/Classes/request/events/InappEvent.swift
+++ b/BluxClient/Classes/request/events/InappEvent.swift
@@ -51,19 +51,16 @@ enum InappDispatchResponse: Codable {
 }
 
 struct InappDispatchRequest: Codable {
-    let events: [Event]
     let bluxUserId: String
     let deviceId: String
     let platform: String = "ios"
 
-    public init(events: [Event], bluxUserId: String, deviceId: String) {
-        self.events = events
+    public init(bluxUserId: String, deviceId: String) {
         self.bluxUserId = bluxUserId
         self.deviceId = deviceId
     }
 
     enum CodingKeys: String, CodingKey {
-        case events
         case bluxUserId = "blux_user_id"
         case deviceId = "device_id"
         case platform


### PR DESCRIPTION
5초마다 한 번씩 inapps/dispatcher에 요청을 보냅니다.
이벤트를 찍을 때 dispatcher를 보내지 않고, 5초마다 한 번씩 생성된 인앱메시지가 있는지 없는지 확인 후 보여주는 용도로 사용합니다.