### PR TITLE
ci: ruby gsub backreference 이스케이핑 수정

### DIFF
--- a/.github/workflows/release-internal.yml
+++ b/.github/workflows/release-internal.yml
@@ -95,7 +95,7 @@ jobs:
           TAG="${{ steps.version.outputs.tag }}"
           SDK_CONFIG_PATH="BluxClient/Classes/SdkConfig.swift"
 
-          ruby -pi -e "gsub(/^(\s*static var sdkVersion\s*=\s*)\".+\"/, %Q(\\1\"${TAG}\"))" "$SDK_CONFIG_PATH"
+          ruby -pi -e "gsub(/^(\s*static var sdkVersion\s*=\s*)\".+\"/, %Q(\\\\1\"${TAG}\"))" "$SDK_CONFIG_PATH"
 
           UPDATED=$(ruby -ne 'if $_ =~ /sdkVersion\s*=\s*"([^"]+)"/; puts $1; exit; end' "$SDK_CONFIG_PATH")
           if [ "$UPDATED" != "$TAG" ]; then


### PR DESCRIPTION
%Q() 안에서 \1이 옥탈 이스케이프로 해석되어 sdkVersion 업데이트가
실패하던 문제를 수정한다. release-personal.sh와 동일하게 \\\\1로 변경.