### PR TITLE
build: sdkVersion을 0.0.1으로 고정하고 patch+1 로직 제거

### DIFF
--- a/.github/workflows/release-internal.yml
+++ b/.github/workflows/release-internal.yml
@@ -50,7 +50,7 @@ jobs:
         id: version
         run: |
           # 버전 SSoT: SdkConfig.swift의 sdkVersion
-          # 생성되는 태그: (BASE_VERSION patch+1)-internal.YYYYMMDD.COMMIT_HASH
+          # 생성되는 태그: BASE_VERSION-internal.YYYYMMDD.COMMIT_HASH
           SDK_CONFIG_PATH="BluxClient/Classes/SdkConfig.swift"
           BASE_VERSION=$(ruby -ne 'if $_ =~ /sdkVersion\s*=\s*"([^"]+)"/; puts $1; exit; end' "$SDK_CONFIG_PATH")
 
@@ -59,10 +59,9 @@ jobs:
             exit 1
           fi
 
-          NEXT_BASE_VERSION=$(echo "$BASE_VERSION" | awk -F. 'BEGIN{OFS="."} {$NF=$NF+1; print $0}')
           DATE=$(date +%Y%m%d)
           COMMIT_HASH="$(git rev-parse --short HEAD)"
-          TAG="${NEXT_BASE_VERSION}-internal.${DATE}.${COMMIT_HASH}"
+          TAG="${BASE_VERSION}-internal.${DATE}.${COMMIT_HASH}"
 
           echo "base_version=$BASE_VERSION" >> $GITHUB_OUTPUT
           echo "tag=$TAG" >> $GITHUB_OUTPUT

--- a/BluxClient/Classes/SdkConfig.swift
+++ b/BluxClient/Classes/SdkConfig.swift
@@ -14,8 +14,11 @@ public enum SdkType: String {
 }
 
 enum SdkConfig {
-    /// 최신 프로덕션 버전 (SSoT). 배포 스크립트/워크플로우 실행 시 풀 태그 버전으로 임시 변경됨.
-    static var sdkVersion = "0.6.11"
+    /// 버전 SSoT. 배포 스크립트/워크플로우에서 빌드 시 실제 버전으로 변경됩니다. 이 값은 직접 수정하지 않습니다.
+    /// - release-personal.sh: 로컬에서 임시 변경 (커밋 안 함)
+    /// - release-internal.yml: 워크플로우에서 임시 변경 (커밋 안 함)
+    /// - release-prod.yml: 워크플로우에서 release 브랜치에 커밋
+    static var sdkVersion = "0.0.1"
     static var sdkType: SdkType = .native
 
     static var bluxAppGroupNameKey = "BluxAppGroupName"

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - BluxClient (0.6.11)
+  - BluxClient (0.0.1)
 
 DEPENDENCIES:
   - BluxClient (from `../`)
@@ -9,7 +9,7 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  BluxClient: 9e266d423d51c3f6d810217174fe9c362b4f50a6
+  BluxClient: 084474b892230e61a8ae51eac3ecf5e73d3e49f0
 
 PODFILE CHECKSUM: d004a92b388fd621686b00714837a748b785f544
 

--- a/scripts/release-personal.sh
+++ b/scripts/release-personal.sh
@@ -9,10 +9,10 @@
 #   ./scripts/release-personal.sh           # GitHub username 자동 감지
 #   ./scripts/release-personal.sh johndoe   # username 직접 지정
 #
-# 생성되는 태그: (BASE_VERSION patch+1)-USERNAME.YYYYMMDD.COMMIT_HASH
-# 예: BASE_VERSION=0.6.11 → 0.6.12-johndoe.20260225.abc1234
+# 생성되는 태그: BASE_VERSION-USERNAME.YYYYMMDD.COMMIT_HASH
+# 예: BASE_VERSION=0.0.1 → 0.0.1-johndoe.20260225.abc1234
 #
-# 버전 SSoT: SdkConfig.swift의 sdkVersion (최신 프로덕션 버전)
+# 버전 SSoT: SdkConfig.swift의 sdkVersion
 # podspec은 SdkConfig.swift에서 버전을 읽으므로, SdkConfig.swift만 변경하면 됨
 
 set -euo pipefail
@@ -89,8 +89,6 @@ if [ -z "$BASE_VERSION" ]; then
     die "Failed to parse sdkVersion from $SDK_CONFIG_PATH"
 fi
 
-NEXT_BASE_VERSION=$(echo "$BASE_VERSION" | awk -F. 'BEGIN{OFS="."} {$NF=$NF+1; print $0}')
-
 # GitHub username 자동 감지 (gh CLI 사용) 또는 git config에서 추출
 if [ -z "$GITHUB_USERNAME" ]; then
     if command -v gh &> /dev/null && gh auth status &> /dev/null 2>&1; then
@@ -111,7 +109,7 @@ fi
 DATE=$(date +%Y%m%d)
 COMMIT_HASH=$(git rev-parse --short HEAD)
 
-TAG="${NEXT_BASE_VERSION}-${GITHUB_USERNAME}.${DATE}.${COMMIT_HASH}"
+TAG="${BASE_VERSION}-${GITHUB_USERNAME}.${DATE}.${COMMIT_HASH}"
 
 validate_tag "$TAG"
 


### PR DESCRIPTION
# 📝 Changes

main의 `SdkConfig.sdkVersion`을 `0.0.1`로 고정하여 버전 관리를 제거합니다. 배포 워크플로우/스크립트가 빌드 시 실제 버전으로 변경하므로 main에서 직접 관리할 필요가 없습니다.

- `SdkConfig.swift`: sdkVersion `0.6.11` → `0.0.1`, 버전 변경 주체별 동작을 주석에 명시
- `release-internal.yml`: patch+1 계산 제거, `BASE_VERSION`을 그대로 사용하여 `0.0.1-internal.DATE.HASH` 태그 생성
- `release-personal.sh`: 동일하게 patch+1 제거, `0.0.1-USERNAME.DATE.HASH` 태그 생성

# Tests you conducted

- `release.personal.sh`

# ⛑ QA Test Cases

- [x] 테스트가 필요 없습니다 (체크하면 QA 라벨이 자동으로 추가되지 않습니다.)

-