### PR TITLE
fix: 콜드 스타트 시 notificationUrlOpenOptions가 기본값으로 리셋되는 문제 수정

### DIFF
--- a/BluxClient/Classes/SdkConfig.swift
+++ b/BluxClient/Classes/SdkConfig.swift
@@ -32,7 +32,24 @@ enum SdkConfig {
 
     static var logLevel: LogLevel = .verbose
     static var requestPermissionOnLaunch: Bool = false
-    static var notificationUrlOpenOptions: NotificationUrlOpenOptions = .init()
+    private static var notificationUrlOpenOptionsKey = "bluxNotificationUrlOpenOptions"
+    static var notificationUrlOpenOptions: NotificationUrlOpenOptions {
+        set {
+            UserDefaults(suiteName: bluxSuiteName)?.set(
+                newValue.httpUrlOpenTarget.rawValue,
+                forKey: notificationUrlOpenOptionsKey
+            )
+        }
+        get {
+            guard let rawValue = UserDefaults(suiteName: bluxSuiteName)?
+                .object(forKey: notificationUrlOpenOptionsKey) as? Int,
+                let target = HttpUrlOpenTarget(rawValue: rawValue)
+            else {
+                return .init()
+            }
+            return NotificationUrlOpenOptions(httpUrlOpenTarget: target)
+        }
+    }
 
     /// Save bluxId in user defaults (local storage)
     private static var bluxIdKey = "bluxId"


### PR DESCRIPTION
## Summary
- 프로세스 사망 후 콜드 스타트 시 `notificationUrlOpenOptions`가 메모리 기본값(`.internalWebView`)으로 리셋되어 사용자 설정값이 무시되던 문제 수정
- `setNotificationUrlOpenOptions` 호출 시 UserDefaults에 영속화하고, URL open 시점에 UserDefaults 값을 우선 조회하도록 변경

## Changes
- **`SdkConfig`**: `notificationUrlOpenOptions`를 단순 static 변수에서 UserDefaults 기반 computed property로 변경

## Test
- [ ] 네이티브/Flutter 앱에서 포그라운드/백그라운드/콜드스타트 × `internalWebView`/`externalBrowser`/`none` (2×3×3) 수동 테스트

🤖 Generated with [Claude Code](https://claude.com/claude-code)