### PR TITLE
feat: Custom HTML resize API 확장 (절대 위치 지정)

### DIFF
--- a/BluxClient/Classes/BannerWindow.swift
+++ b/BluxClient/Classes/BannerWindow.swift
@@ -126,6 +126,56 @@ final class BannerWindow: UIWindow {
         
     }
     
+    /// Custom HTML 절대 위치 지정 (safe area 적용 안 함)
+    func updateLayout(options: [String: Any]) {
+        let screenBounds = UIScreen.main.bounds
+
+        let width = parseNumber(options["width"]) ?? screenBounds.width
+        let height = parseNumber(options["height"]) ?? screenBounds.height
+
+        let x: CGFloat
+        if let left = parseNumber(options["left"]) {
+            x = left
+        } else if let right = parseNumber(options["right"]) {
+            x = screenBounds.width - width - right
+        } else {
+            x = (screenBounds.width - width) / 2
+        }
+
+        let y: CGFloat
+        if let top = parseNumber(options["top"]) {
+            y = top
+        } else if let bottom = parseNumber(options["bottom"]) {
+            y = screenBounds.height - height - bottom
+        } else {
+            y = 0
+        }
+
+        let newFrame = CGRect(x: x, y: y, width: width, height: height)
+
+        if isHidden {
+            frame = newFrame
+            alpha = 0
+            isHidden = false
+            makeKeyAndVisible()
+
+            UIView.animate(withDuration: 0.2) {
+                self.alpha = 1
+            }
+        } else {
+            UIView.animate(withDuration: 0.2) {
+                self.frame = newFrame
+            }
+        }
+    }
+
+    private func parseNumber(_ value: Any?) -> CGFloat? {
+        if let v = value as? CGFloat { return v }
+        if let v = value as? Int { return CGFloat(v) }
+        if let v = value as? Double { return CGFloat(v) }
+        return nil
+    }
+
     private func getSafeAreaInsets() -> UIEdgeInsets {
         if #available(iOS 13.0, *) {
             return windowScene?.windows.first?.safeAreaInsets ?? .zero
@@ -212,15 +262,23 @@ extension BannerWindow: WKScriptMessageHandler {
         
         // resize 액션은 내부에서 직접 처리
         if action == "resize" {
-            if let height = data["height"] as? CGFloat,
-               let location = data["location"] as? String {
-                DispatchQueue.main.async {
-                    self.updateLayout(height: height, location: location)
+            if let location = data["location"] as? String {
+                // 기존 배너용 resize (location 기반)
+                let height: CGFloat?
+                if let h = data["height"] as? CGFloat { height = h }
+                else if let h = data["height"] as? Int { height = CGFloat(h) }
+                else if let h = data["height"] as? Double { height = CGFloat(h) }
+                else { height = nil }
+
+                if let height = height {
+                    DispatchQueue.main.async {
+                        self.updateLayout(height: height, location: location)
+                    }
                 }
-            } else if let height = data["height"] as? Int,
-                      let location = data["location"] as? String {
+            } else {
+                // Custom HTML 절대 위치 지정
                 DispatchQueue.main.async {
-                    self.updateLayout(height: CGFloat(height), location: location)
+                    self.updateLayout(options: data)
                 }
             }
             return

--- a/BluxClient/Classes/InappService.swift
+++ b/BluxClient/Classes/InappService.swift
@@ -209,37 +209,34 @@ class InappService {
                     handler: { data in
                         // 이미 BannerWindow로 전환했으면 무시
                         guard !didSwitchToBanner else { return }
-                        
-                        // height 파싱 (CGFloat 또는 Int 또는 Double)
-                        let height: CGFloat?
-                        if let h = data["height"] as? CGFloat {
-                            height = h
-                        } else if let h = data["height"] as? Int {
-                            height = CGFloat(h)
-                        } else if let h = data["height"] as? Double {
-                            height = CGFloat(h)
-                        } else {
-                            height = nil
-                        }
-                        
-                        guard let height = height, let location = data["location"] as? String else {
-                            return
-                        }
-                        
+
                         // 플래그 설정 (중복 실행 방지)
                         didSwitchToBanner = true
-                        
-                        Logger.verbose("INAPP: switching to BannerWindow - height: \(height), location: \(location)")
-                        
+
                         DispatchQueue.main.async {
                             // 기존 모달 dismiss (애니메이션 없이)
                             webviewController.dismiss(animated: false) {
                                 // BannerWindow 생성 (HTML 로드 후 자체적으로 resize 처리)
                                 let bannerWindow = BannerWindow(htmlString: htmlString, baseURL: baseURL)
                                 currentBannerWindow = bannerWindow
-                                
-                                // 초기 크기로 바로 표시 (BannerWindow 내부 resize로 업데이트됨)
-                                bannerWindow.updateLayout(height: height, location: location)
+
+                                if let location = data["location"] as? String {
+                                    // 기존 배너용 resize (location 기반)
+                                    let height: CGFloat?
+                                    if let h = data["height"] as? CGFloat { height = h }
+                                    else if let h = data["height"] as? Int { height = CGFloat(h) }
+                                    else if let h = data["height"] as? Double { height = CGFloat(h) }
+                                    else { height = nil }
+
+                                    if let height = height {
+                                        Logger.verbose("INAPP: switching to BannerWindow - height: \(height), location: \(location)")
+                                        bannerWindow.updateLayout(height: height, location: location)
+                                    }
+                                } else {
+                                    // Custom HTML 절대 위치 지정
+                                    Logger.verbose("INAPP: switching to BannerWindow with custom options")
+                                    bannerWindow.updateLayout(options: data)
+                                }
                                 
                                 // hide 핸들러 등록
                                 bannerWindow.addMessageHandler(for: "hide") { hideData in


### PR DESCRIPTION
# 📝 Changes

- Custom HTML 인앱메시지에서 `BluxBridge.resize({ width, height, top, bottom, left, right })` API를 지원합니다.
- `BannerWindow.updateLayout(options:)` 오버로드 추가 — 절대 위치 지정 (safe area 미적용)
- `InappService` resize 핸들러에서 `location` 유무로 legacy/new format 자동 감지
- 기존 배너 resize 로직은 그대로 유지
- 관련 PR: blux 모노레포, Android SDK

# Tests you conducted

- x

# ⛑ QA Test Cases

- [ ] 테스트가 필요 없습니다 (체크하면 QA 라벨이 자동으로 추가되지 않습니다.)

- 기존 배너 타입 인앱메시지의 resize(height, location)가 정상 동작하는지 확인
- Custom HTML에서 `BluxBridge.resize({ width: 350, height: 60, bottom: 75, left: 16, right: 16 })` 호출 시 정확한 위치에 배치되는지 확인
- resize된 영역 밖의 터치가 뒤쪽 UI로 전달되는지 확인