### PR TITLE
chore: LOCAL URL을 server-public ALB 포트로 변경

### DIFF
--- a/BluxClient/Classes/HTTPClient.swift
+++ b/BluxClient/Classes/HTTPClient.swift
@@ -25,7 +25,7 @@ final class HTTPClient {
     }
 
     enum APIBaseURLByStage: String {
-        case local = "http://localhost:9000/local"
+        case local = "http://localhost:3003/red/red"
         case dev = "https://api.blux.ai/dev"
         case stg = "https://api.blux.ai/stg"
         case prod = "https://api.blux.ai/prod"


### PR DESCRIPTION
# 📝 Changes

server-public의 serverless-offline ALB 서버(포트 3003)에 맞게 LOCAL URL을 수정한다. 기존에는 server 포트(9000)를 가리키고 있어 로컬에서 server-public 엔드포인트(initialize, collect-events 등)를 테스트할 수 없었다.

# Tests you conducted

- Android 실기기에서 로컬 server-public 연동 테스트 완료 (iOS는 동일 구조)

# ⛑ QA Test Cases

- [x] 테스트가 필요 없습니다 (체크하면 QA 라벨이 자동으로 추가되지 않습니다.)

-