### PR TITLE
ci: build 잡에 iOS 플랫폼 설치 스텝 추가

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,9 @@ jobs:
         with:
           xcode-version: "26.0.1"
 
+      - name: Install iOS platform
+        run: xcodebuild -downloadPlatform iOS
+
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:


### PR DESCRIPTION
## Summary

- `macos-26` 러너 이미지가 iOS 26 플랫폼(Simulator Runtime 포함)을 기본 제공하지 않게 변경되면서, `xcodebuild`의 XIB/Storyboard 컴파일 시 `"iOS 26.0 Platform Not Installed"` 에러로 CI 실패 ([run 24381347856](https://github.com/zaikorea/Blux-iOS-SDK/actions/runs/24381347856/job/71205901879))
- `setup-xcode`는 Xcode 선택만 하고 플랫폼을 설치하지 않으므로, `build` 잡에 `xcodebuild -downloadPlatform iOS` 스텝 추가
- 2026-04-02 CI는 성공했었고 워크플로우/코드 변경 없음 → 러너 이미지 업데이트가 원인

## Test plan

- [ ] 이 PR의 CI `build` 잡이 통과하는지 확인
- [ ] `check-pod-lock-freshness` 잡도 정상 통과하는지 확인 (이 잡은 ibtool을 호출하지 않아 수정 불필요)

🤖 Generated with [Claude Code](https://claude.com/claude-code)