### PR TITLE
fix: initialize 재호출로 인한 push_opened 중복 전송 수정

### DIFF
--- a/BluxClient/Classes/BluxClient.swift
+++ b/BluxClient/Classes/BluxClient.swift
@@ -128,6 +128,7 @@ struct UpdatePropertiesBody: Codable {
             || (savedApiKey != nil && savedApiKey != bluxAPIKey)
         if credentialsChanged {
             isActivated = false
+            ColdStartNotificationManager.reset()
         }
 
         // If saved clientId is nil or different, reset deviceId to nil

--- a/BluxClient/Classes/BluxNotificationCenter.swift
+++ b/BluxClient/Classes/BluxNotificationCenter.swift
@@ -32,14 +32,9 @@ public class BluxNotificationCenter: NSObject, UNUserNotificationCenterDelegate 
                 Logger.verbose("No Client ID.")
                 ColdStartNotificationManager.coldStartNotification =
                     notification
-            } else if ColdStartNotificationManager.coldStartNotification?.id
-                == notification.id
-            {
-                // If the ID of coldStartNotification is the same as notificationId, it stops to avoid duplicate execution
-                Logger.verbose("ColdStartNotification exists. Skip didReceive.")
             } else {
                 Logger.verbose("Notification clicked.")
-                notification.trackOpened()
+                ColdStartNotificationManager.trackOpen(notification)
             }
 
             if let bluxDismissLaunchUrl = Bundle.main.object(

--- a/BluxClient/Classes/ColdStartNotificationManager.swift
+++ b/BluxClient/Classes/ColdStartNotificationManager.swift
@@ -11,27 +11,45 @@ import UIKit
 @available(iOSApplicationExtension, unavailable)
 class ColdStartNotificationManager {
     static var coldStartNotification: BluxNotification?
+    private static var hasProcessedLaunchOptions = false
+    private(set) static var lastOpenedNotificationId: String?
 
-    /// Set coldStartNotification in launchOptions
+    /// launchOptions에서 푸시 알림을 파싱해 coldStartNotification에 저장한다.
+    /// WebView 브릿지 환경(네이티브/RN/Flutter)에서는 페이지 전환마다 initialize가 재호출되며 같은 launchOptions가 재전달될 수 있으므로,
+    /// 이미 notification을 소비한 이후에는 재진입을 차단한다.
     static func setColdStartNotification(launchOptions: [UIApplication.LaunchOptionsKey: Any]?) {
+        guard !hasProcessedLaunchOptions else { return }
         if let bluxNotification = BluxNotification.getBluxNotificationFromLaunchOptions(launchOptions: launchOptions) {
             coldStartNotification = bluxNotification
         }
     }
 
-    /// Check and execute coldStartNotification
+    /// launchOptions 경로의 open 처리를 trackOpen(_:)에 위임한다.
+    /// Background로 깨어난 경우(silent push 등)에는 사용자 탭이 아니므로 전송하지 않고, 이후 사용자가 탭하면 didReceive가 trackOpen(_:)을 호출한다.
     static func process() {
-        guard let notification = coldStartNotification else {
-            return
-        }
+        guard let notification = coldStartNotification else { return }
+        // launchOptions에서 실제로 notification을 소비한 경우에만 재진입 차단 플래그를 세운다.
+        // initialize(nil, ...)이 먼저 호출돼도 이후의 initialize(launchOptions, ...)이 정상적으로 처리되도록 하기 위함.
+        hasProcessedLaunchOptions = true
+        coldStartNotification = nil
+        if UIApplication.shared.applicationState == .background { return }
+        trackOpen(notification)
+    }
 
-        if UIApplication.shared.applicationState == .background {
-            // When called in the background, the app is not turned on
-            // Set coldStartNotification to nil to be clicked in notificationCenter
-            coldStartNotification = nil
-        } else {
-            // If it is not in the background state, process clicked and keep coldStartNotification to avoid duplicate processing in notificationCenter
-            notification.trackOpened()
-        }
+    /// push_opened 트래킹의 단일 진입점.
+    /// launchOptions 경로(process)와 UN delegate 경로(didReceive) 모두 이 메서드를 통해야 하며, 동일 notification id에 대해 한 번만 전송된다.
+    static func trackOpen(_ notification: BluxNotification) {
+        guard lastOpenedNotificationId != notification.id else { return }
+        lastOpenedNotificationId = notification.id
+        notification.trackOpened()
+    }
+
+    /// credential 전환(stage/app 변경) 시 상태를 초기화한다.
+    /// 보류된 cold-start notification과 소비 플래그를 리셋해 새 credential 아래에서 launchOptions가 다시 처리되도록 한다.
+    /// lastOpenedNotificationId는 유지한다. notification id는 서버가 발급하는 전역 유일 ObjectId이므로 credential 경계를 넘어도 dedup 키로 유효하며,
+    /// 유지함으로써 didReceive가 먼저 세팅한 dedup 키가 이후 launchOptions 경로에서 지워지는 엣지케이스를 막는다.
+    static func reset() {
+        coldStartNotification = nil
+        hasProcessedLaunchOptions = false
     }
 }


### PR DESCRIPTION
## Summary

`initialize`가 여러 번 호출되면서 매번 동일 `launchOptions`가 재전달되면 같은 푸시의 `push_opened`가 반복 전송되던 버그 수정. 실제 발생 계기는 WebView 기반 하이브리드 앱(네이티브/RN/Flutter)에서 페이지 전환마다 브릿지가 `initialize`를 재호출한 케이스.

관련 이슈: https://teamslack-k7w6420.slack.com/archives/C09SH6T3DGV/p1776228007321809

## Root cause

푸시 탭으로 앱이 켜지면 iOS가 "어떤 푸시로 켜졌는지"를 담은 데이터(`launchOptions`)를 SDK에 넘겨줘 `push_opened` 이벤트를 전송한다.

`initialize`가 같은 `launchOptions`로 여러 번 호출되면 한 번 탭한 푸시가 매 호출마다 새 탭처럼 취급되어 이벤트가 반복 전송된다. 가장 흔한 케이스는 WebView 브릿지가 페이지 전환마다 `initialize`를 재호출하면서 static하게 보관된 동일 `launchOptions`를 매번 재전달하는 상황.

거기에 푸시 탭을 SDK에 알리는 경로가 두 개(`launchOptions` 경로와 iOS의 `didReceive` 경로)인데 서로 중복 방지 상태를 공유하지 않아서 경로 순서가 엇갈리면 같은 푸시가 각각 한 번씩 전송되기도 한다.

## Fix

OneSignal이 쓰는 방식(단일 진입점 + ID 기반 dedup)을 참고해 3중 방어를 둔다:

1. **단일 진입점**: `launchOptions` 경로와 `didReceive` 경로 모두 `trackOpen(_:)` 하나를 거치게 통합 → 두 경로가 상태를 공유.
2. **ID로 중복 차단**: 마지막 처리한 푸시 ID를 기억해두고 같은 ID가 또 오면 무시 (`lastOpenedNotificationId`).
3. **재파싱 차단**: `launchOptions`를 한 번 소비했으면 같은 데이터가 또 들어와도 파싱 자체를 스킵 (`hasProcessedLaunchOptions`). 단 실제로 푸시를 소비한 경우에만 플래그를 세워 `initialize(nil)`이 먼저 호출돼도 이후 `initialize(launchOptions)`가 정상 동작.

## Test plan

시뮬레이터(iPhone 17 Pro, iOS 26) + stg 환경에서 검증 완료:

- [x] 시나리오 1: 정상 cold start 푸시 탭 → push_opened 1건
- [x] 시나리오 2: WebView 브릿지 재init x5 → push_opened 추가 0건 (핵심)
- [x] 시나리오 3: Foreground 푸시 수신 → push_opened 0건
- [x] 시나리오 4: Background 탭 → push_opened 1건
- [x] 시나리오 5: Silent push → push_opened 0건

🤖 Generated with [Claude Code](https://claude.com/claude-code)