### PR TITLE
fix: credential/user 전환 시 이전 세션 상태 누수 방지

### DIFF
--- a/BluxClient/Classes/BluxClient.swift
+++ b/BluxClient/Classes/BluxClient.swift
@@ -119,16 +119,24 @@ struct UpdatePropertiesBody: Codable {
         SdkConfig.requestPermissionOnLaunch = requestPermissionOnLaunch
 
         Logger.verbose("Initialize BluxClient with Application ID: \(bluxApplicationId).")
-        SdkConfig.apiKeyInUserDefaults = bluxAPIKey
 
         // credentials가 변경된 경우 재초기화 허용 (stage 전환 후 재초기화 지원)
+        // 쓰기 전에 저장된 값을 먼저 읽어야 API key만 교체되는 경우도 감지 가능.
         let savedApplicationId = SdkConfig.clientIdInUserDefaults
         let savedApiKey = SdkConfig.apiKeyInUserDefaults
         let credentialsChanged = (savedApplicationId != nil && savedApplicationId != bluxApplicationId)
             || (savedApiKey != nil && savedApiKey != bluxAPIKey)
+        // 프로세스 내에서 initialize가 이미 호출된 상태에서 credential이 전환된 경우 식별 (isActivated 리셋 전 값 사용).
+        // 프로세스 첫 initialize 호출 시에는 launchOptions가 정당한 데이터이므로 구분이 필요.
+        let isInProcessCredentialSwitch = credentialsChanged && isActivated
+
+        SdkConfig.apiKeyInUserDefaults = bluxAPIKey
+
         if credentialsChanged {
             isActivated = false
             ColdStartNotificationManager.reset()
+            // 이전 credential 세션에서 대기 중이던 클릭이 새 credential로 재전달되지 않도록 초기화한다.
+            EventHandlers.unhandledNotification = nil
         }
 
         // If saved clientId is nil or different, reset deviceId to nil
@@ -144,8 +152,10 @@ struct UpdatePropertiesBody: Codable {
             return
         }
 
+        // 프로세스 내 credential 전환 시 전달된 launchOptions는 이전 credential의 푸시 페이로드일 수 있으므로 재처리하지 않는다.
+        // (BluxNotification에는 credential 식별자가 없어 현재 credential 소속 여부를 판별할 수 없음.)
         ColdStartNotificationManager.setColdStartNotification(
-            launchOptions: launchOptions)
+            launchOptions: isInProcessCredentialSwitch ? nil : launchOptions)
 
         ColdStartNotificationManager.process()
 
@@ -232,6 +242,9 @@ struct UpdatePropertiesBody: Codable {
 
     /// Signout from the device
     @objc public static func signOut() {
+        // 이전 유저 세션에서 대기 중이던 클릭이 다음 유저로 재전달되지 않도록 초기화한다.
+        EventHandlers.unhandledNotification = nil
+
         guard
             let clientId = SdkConfig.clientIdInUserDefaults,
             let bluxId = SdkConfig.bluxIdInUserDefaults,


### PR DESCRIPTION
## Summary

credential(app/stage) 또는 user 전환 시 이전 세션의 상태가 새 세션으로 누수되는 3가지 이슈 수정.

실 프로덕션 영향은 제한적이며, 대부분 방어적 개선.

## Fix

### 1. credential 변경 감지 타이밍 버그

`apiKeyInUserDefaults`를 쓰기 전에 `savedApiKey`를 읽도록 순서 수정. 기존 코드는 쓰기가 먼저여서 API key만 교체되는 경우 `credentialsChanged`가 항상 false가 되어 reset/clear 경로가 실행되지 않았음.

### 2. 프로세스 내 credential 전환 시 이전 `launchOptions` 재처리 차단

이전 credential의 `launchOptions`가 새 credential로 재처리되지 않도록 차단. 단 프로세스 첫 `initialize` 호출에서는 `launchOptions`가 정당한 데이터이므로 `isActivated` 값을 함께 확인해 `isInProcessCredentialSwitch`로 판단.

### 3. 지연된 notification click 재전달 차단

이전 세션에서 지연된 `EventHandlers.unhandledNotification`이 다음 세션(다른 credential 또는 다른 user)으로 재전달되지 않도록 `credentialsChanged` 블록과 `signOut()`에서 초기화.

## Test plan

시뮬레이터(iPhone 17 Pro, iOS 26) + stg 환경에서 검증 완료:

- [x] 시나리오 1: API key만 교체 → `credentialsChanged=true` 감지되어 reset/clear 경로 실행
- [x] 시나리오 2: credential 바뀐 상태에서 cold start 첫 `initialize` → `launchOptions` 정상 처리 (drop 안 됨)
- [x] 시나리오 3: 프로세스 내 credential 전환 → 이전 `launchOptions` drop (crm-events 추가 전송 0건 확인)
- [x] 시나리오 4: handler 미등록 상태에서 탭 후 `signOut` → 다음 handler 등록 시 `NotificationClickedHandler has been registered`만 로그, `Found unhandledNotification` 로그 없음 → replay 차단 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)