### PR TITLE
ci: release 워크플로우에 iOS 플랫폼 설치 스텝 추가

### DIFF
--- a/.github/workflows/release-internal.yml
+++ b/.github/workflows/release-internal.yml
@@ -25,6 +25,9 @@ jobs:
         with:
           xcode-version: "26.0.1"
 
+      - name: Install iOS platform
+        run: xcodebuild -downloadPlatform iOS
+
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/release-prod.yml
+++ b/.github/workflows/release-prod.yml
@@ -86,6 +86,9 @@ jobs:
         with:
           xcode-version: "26.0.1"
 
+      - name: Install iOS platform
+        run: xcodebuild -downloadPlatform iOS
+
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:


### PR DESCRIPTION
## Summary

2026-04-14부터 release 워크플로우(release-internal, release-prod)가 연속 실패 중. 원인은 macos-26 러너가 iOS 26 플랫폼을 기본 제공하지 않아 `pod lib lint`의 내부 xcodebuild가 destination을 찾지 못하는 것.

3503542에서 `ci.yml`에만 추가됐던 `xcodebuild -downloadPlatform iOS` 스텝을 두 release 워크플로우에도 추가.

## Failure log

```
- ERROR | [iOS] xcodebuild: Returned an unsuccessful exit code
- NOTE  | [iOS] xcodebuild: error: Unable to find a destination matching the provided destination specifier
```

## Test plan

머지 후 다음 main push에서 Internal Release 성공 확인.

🤖 Generated with [Claude Code](https://claude.com/claude-code)