### PR TITLE
fix: 세션 전환 시 pending 상태(이벤트 배치/인앱/큐) drain

### DIFF
--- a/BluxClient/Classes/BluxClient.swift
+++ b/BluxClient/Classes/BluxClient.swift
@@ -137,6 +137,13 @@ struct UpdatePropertiesBody: Codable {
             ColdStartNotificationManager.reset()
             // 이전 credential 세션에서 대기 중이던 클릭이 새 credential로 재전달되지 않도록 초기화한다.
             EventHandlers.unhandledNotification = nil
+            // 이전 세션에서 배칭된 이벤트가 새 세션의 bluxId로 전송되는 것을 막는다.
+            EventService.clearPendingBatch()
+            // 이전 세션에서 표시 중이던 인앱 메시지를 닫고 대기 큐도 비운다.
+            InappService.dismissCurrentInApp()
+            InappService.clearInappQueue()
+            // 대기 중인 이벤트 태스크를 drop해 새 credential 아래에서 실행되지 않도록 한다.
+            EventQueue.shared.clearPending()
         }
 
         // If saved clientId is nil or different, reset deviceId to nil
@@ -244,6 +251,13 @@ struct UpdatePropertiesBody: Codable {
     @objc public static func signOut() {
         // 이전 유저 세션에서 대기 중이던 클릭이 다음 유저로 재전달되지 않도록 초기화한다.
         EventHandlers.unhandledNotification = nil
+        // 이전 유저의 배칭된 이벤트가 signOut 이후 재발급되는 bluxId로 전송되는 것을 막는다.
+        EventService.clearPendingBatch()
+        // 이전 유저에게 표시 중이던 인앱 메시지를 닫고 대기 큐도 비운다.
+        InappService.dismissCurrentInApp()
+        InappService.clearInappQueue()
+        // 이전 유저의 대기 중인 이벤트 태스크를 drop해 새 anonymous identity로 실행되지 않도록 한다.
+        EventQueue.shared.clearPending()
 
         guard
             let clientId = SdkConfig.clientIdInUserDefaults,

--- a/BluxClient/Classes/EventQueue.swift
+++ b/BluxClient/Classes/EventQueue.swift
@@ -26,6 +26,14 @@ class EventQueue {
         }
     }
 
+    /// 세션 경계(credential 변경, signOut)에서 대기 중인 이벤트 태스크 제거.
+    /// isInitialized는 건드리지 않아 이후 신규 addEvent는 정상 처리된다.
+    func clearPending() {
+        queue.async { [weak self] in
+            self?.eventsQueue.removeAll()
+        }
+    }
+
     /// 동기 작업용 (기존 호환)
     func addEvent(_ eventTask: @escaping () -> Void) {
         addEvent { done in

--- a/BluxClient/Classes/EventService.swift
+++ b/BluxClient/Classes/EventService.swift
@@ -62,6 +62,17 @@ class EventService {
         }
     }
 
+    /// 세션 전환 시 배치 버퍼 드레인 (credential 변경, signOut 등).
+    /// 이전 세션의 이벤트가 새 세션의 bluxId로 전송되어 attribution이 오염되는 것을 방지한다.
+    /// 이미 전송 시작된 batch는 막지 못함 (pending 버퍼만 비움).
+    static func clearPendingBatch() {
+        batchQueue.async {
+            pendingEvents.removeAll()
+            batchWorkItem?.cancel()
+            batchWorkItem = nil
+        }
+    }
+
     /// 배치 전송 실행 (batchQueue 내에서만 호출)
     private static func flushBatch() {
         let eventsToSend = pendingEvents

--- a/BluxClient/Classes/InappService.swift
+++ b/BluxClient/Classes/InappService.swift
@@ -173,6 +173,15 @@ class InappService {
         }
     }
 
+    /// 세션 경계(credential 변경, signOut)에서 대기 중인 인앱 큐 제거.
+    /// dismissCurrentInApp()이 현재 표시 중만 닫고 processWebViewQueue로 다음을 present하므로,
+    /// 큐까지 비워야 이전 세션 inapp이 새 세션에 표시되지 않는다.
+    static func clearInappQueue() {
+        DispatchQueue.main.async {
+            webViewQueue.removeAll()
+        }
+    }
+
     private static func presentInappWebview(
         _ notificationId: String,
         _ htmlString: String,


### PR DESCRIPTION
## Summary

credential(stage/app) 변경과 signOut 경계에서 이전 세션 pending 상태가 새 세션으로 섞이는 4가지 누수 지점 차단.

실 프로덕션 영향은 제한적이며, 대부분 방어적 개선.

## Fix

### 1. 배치 이벤트 버퍼 드레인 (attribution 오염 방지)

`EventService`는 100ms 배치 윈도우(`pendingEvents` + `batchWorkItem`)로 이벤트를 모아 전송한다. 배치 윈도우가 열린 채로 `signOut`/`credentialsChanged`가 발생하면:

- `signOut` 성공 응답에서 `bluxIdInUserDefaults`가 **새 anonymous user의 bluxId로 교체**됨
- 이 사이 flush된 배치가 새 bluxId로 이전 유저 이벤트를 전송 → cross-session attribution 오염

`EventService.clearPendingBatch()` 추가해 `pendingEvents` 제거 + `batchWorkItem` 취소. `credentialsChanged` 블록과 `signOut()` 진입부에서 호출.

### 2. 표시 중인 인앱 메시지 닫기

이전 세션 유저에게 표시되던 인앱 메시지가 새 세션으로 잔존하면 UI 혼란. 기존 `InappService.dismissCurrentInApp()`을 `credentialsChanged` 블록과 `signOut()` 진입부에서 호출.

### 3. 대기 중인 인앱 큐 제거

`InappService.dismissCurrentInApp()`은 현재 표시 중인 것만 닫고 내부에서 `processWebViewQueue()`로 다음 inapp을 present한다. 여러 inapp이 `webViewQueue`에 쌓여있던 상태에서 세션이 전환되면, 현재 것이 닫힌 직후 큐의 다음 inapp이 **새 세션 UI에 표시**될 수 있다. `InappService.clearInappQueue()` 추가해 세션 경계에서 `webViewQueue`를 비움.

### 4. 대기 중인 이벤트 태스크 drop

`EventQueue.shared`의 `eventsQueue`에 쌓인 대기 태스크가 세션 전환 후 새 identity로 실행되지 않도록 차단. `EventQueue.clearPending()` 추가 (eventsQueue만 비움, `isInitialized` 유지). `credentialsChanged` 블록과 `signOut()` 진입부에서 호출.

## Test plan

시뮬레이터(iPhone 17 Pro, iOS 26) + stg 환경 + MongoDB blux-dev (blux + blux_event DB) 검증.

- [x] **정상 signOut 플로우**: 초기화 → signOut → 새 anonymous bluxId 생성. MongoDB `blux_users`에 신규 user 기록 확인
- [x] **배치 drain**: `sendEvent` 후 `signOut` → 이벤트가 이전 bluxId로 정확히 attribute. MongoDB `events` 컬렉션에서 cross-session attribution 오염 0건 확인
- [x] **isInitialized 유지**: `signOut` 후 `sendEvent` → 새 bluxId로 정상 전송. `clearPending` 호출 후에도 `processNext` 정상 실행
- [x] **연속 signOut**: 두 번 연속 `signOut` 각각 HTTP 성공, 매번 새 anonymous bluxId. 크래시 없음
- [x] **초기화 전 signOut**: guard early return으로 안전 처리, 크래시 없음 (drain 4개 모두 noop)
- [x] **credentialsChanged (API key 교체)**: 재초기화 중 drain 4개 모두 호출, 새 bluxId/deviceId 생성. `credentialsChanged` 블록 전체 경로 안전성 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)