### PR TITLE
fix: initialize 실패 시 isActivated 롤백해 재시도 경로 보장

### DIFF
--- a/BluxClient/Classes/BluxClient.swift
+++ b/BluxClient/Classes/BluxClient.swift
@@ -196,6 +196,7 @@ struct UpdatePropertiesBody: Codable {
                     requestPermissionForNotifications()
                 }
             case let .failure(error):
+                isActivated = false
                 Logger.error("Failed to initialize device: \(error).")
                 completion(error as NSError)
             }


### PR DESCRIPTION
# 📝 Changes

## 무슨 문제였나

`initialize`가 한 번 실패한 뒤, 같은 credential로 다시 호출하면 **겉으론 성공처럼 보이지만 실제로는 아무것도 안 하는 상태**가 된다.

원인은 `initialize` 진입 시점에 `isActivated = true`를 세팅하는데(hybrid 앱에서 `/initialize` 중복 호출 방지용), `DeviceService.initializeDevice`가 실패해도 이 플래그가 `false`로 되돌려지지 않는 것. 다음 `initialize` 호출은 `isActivated`가 true라서 네트워크 요청 없이 `completion(nil)`만 호출하고 리턴 → 호출자는 "성공"으로 받지만 내부 `bluxId`는 여전히 nil → 이후 `sendEvent`/`signIn` 등은 `bluxId` 가드에 걸려 조용히 drop.

결과: 첫 `initialize`가 네트워크 오류 등으로 한 번 실패하면, 앱 재시작 전까지 SDK가 사실상 먹통.

## 뭘 고쳤나

`DeviceService.initializeDevice` failure 분기에서 `isActivated = false`로 롤백. 같은 credential로 재호출 시 정상적으로 네트워크 재시도가 일어난다.

기존 동작(DeviceService 호출 **전에** `isActivated = true`로 세팅해 in-flight 중복 호출 차단)은 그대로 유지.

수정 범위: `BluxClient/Classes/BluxClient.swift` 1줄 추가.

# Tests you conducted

Debug-stg 빌드 + iPhone 17 Pro 시뮬레이터(iOS 26.0) + `api.blux.ai/stg` + MongoDB dev에서 E2E 검증.

**실패 → 재시도 시나리오 (이 PR의 핵심)**

1. `HTTPClient`의 LOCAL URL을 임시로 존재하지 않는 포트(`127.0.0.1:9999`)로 변경해 연결 실패 강제.
2. clean install 후 LOCAL stage에서 Initialize 클릭 → "Could not connect to the server" 에러, `blux_users` 카운트 47 유지.
3. STG로 stage 전환 후 Initialize 재클릭 → 성공 dialog + `blux_users` 47 → 48 (실제 BluxUser 생성).

fix가 없었다면 3번에서 `isActivated=true`가 유지되어 early-return → 성공 dialog는 뜨지만 새 user는 생성 안 됐을 것. 실제로 증가가 관찰됐으므로 롤백 경로가 정상 작동.

**회귀 체크**

- Initialize → SignIn(userId="team") → Send Custom Event(signup2) → SignOut 전체 흐름에서 기대한 서버 side effect 모두 확인:
  - BluxUser 생성, `visit` 이벤트 자동 전송
  - SignIn 시 기존 "team" user에 device merge
  - Custom event의 `custom_event_properties`가 서버에 정확히 반영
  - SignOut 시 새 anonymous user 재발급 + device 이전

# ⛑ QA Test Cases

- [x] 테스트가 필요 없습니다 (체크하면 QA 라벨이 자동으로 추가되지 않습니다.)