### PR TITLE
fix: HTTPClient request 생성 실패 시 completion을 호출해 호출부 대기 해소

### DIFF
--- a/BluxClient/Classes/EventService.swift
+++ b/BluxClient/Classes/EventService.swift
@@ -104,6 +104,9 @@ class EventService {
 
                 if let error = error {
                     Logger.error("Failed to send event request: \(error)")
+                    if case HTTPClient.HTTPError.invalidRequest = error {
+                        return
+                    }
                     // 실패 시 지수 백오프
                     let nextPollDelay = cachedPollDelayMs > 1000 * 60 * 60 * 24 ? cachedPollDelayMs : cachedPollDelayMs * 2
                     cachedPollDelayMs = nextPollDelay

--- a/BluxClient/Classes/HTTPClient.swift
+++ b/BluxClient/Classes/HTTPClient.swift
@@ -19,9 +19,10 @@ final class HTTPClient {
         case DELETE
     }
 
-    private enum HTTPError: Error {
+    enum HTTPError: Error {
         case transportError(Error)
         case serverSideError(Int)
+        case invalidRequest
     }
 
     enum APIBaseURLByStage: String {
@@ -156,8 +157,10 @@ final class HTTPClient {
     func get<T: Codable>(
         path: String, completion: @escaping (T?, Error?) -> Void
     ) {
-        guard let request = createRequest(path: path)
-        else { return }
+        guard let request = createRequest(path: path) else {
+            completion(nil, HTTPError.invalidRequest)
+            return
+        }
 
         Logger.verbose("GET Request - path:\(path)")
         let task = createAsyncTask(request: request, completion: completion)
@@ -167,8 +170,10 @@ final class HTTPClient {
     func post<T: Codable, V: Codable>(
         path: String, body: T, completion: @escaping (V?, Error?) -> Void
     ) {
-        guard let request = createRequestWithBody(method: HTTPMethodWithBody.POST, path: path, body: body)
-        else { return }
+        guard let request = createRequestWithBody(method: HTTPMethodWithBody.POST, path: path, body: body) else {
+            completion(nil, HTTPError.invalidRequest)
+            return
+        }
 
         Logger.verbose("POST Request - path:\(path) body:\(body)")
         let task = createAsyncTask(request: request, completion: completion)
@@ -178,8 +183,10 @@ final class HTTPClient {
     func put<T: Codable, V: Codable>(
         path: String, body: T, completion: @escaping (V?, Error?) -> Void
     ) {
-        guard let request = createRequestWithBody(method: HTTPMethodWithBody.PUT, path: path, body: body)
-        else { return }
+        guard let request = createRequestWithBody(method: HTTPMethodWithBody.PUT, path: path, body: body) else {
+            completion(nil, HTTPError.invalidRequest)
+            return
+        }
 
         Logger.verbose("PUT Request - path:\(path) body:\(body)")
         let task = createAsyncTask(request: request, completion: completion)
@@ -189,8 +196,10 @@ final class HTTPClient {
     func patch<T: Codable, V: Codable>(
         path: String, body: T, completion: @escaping (V?, Error?) -> Void
     ) {
-        guard let request = createRequestWithBody(method: HTTPMethodWithBody.PATCH, path: path, body: body)
-        else { return }
+        guard let request = createRequestWithBody(method: HTTPMethodWithBody.PATCH, path: path, body: body) else {
+            completion(nil, HTTPError.invalidRequest)
+            return
+        }
 
         Logger.verbose("PATCH Request - path:\(path) body:\(body)")
         let task = createAsyncTask(request: request, completion: completion)


### PR DESCRIPTION
# 📝 Changes

## 무슨 문제였나

`HTTPClient`의 `get`/`post`/`put`/`patch`는 `URLRequest` 생성에 실패하면(= `clientId`가 nil이거나 URL 파싱 실패) `guard ... else { return }`로 조용히 빠져나가서 **completion 콜백이 영영 호출되지 않았다.** 그 결과로 두 개의 심각한 교착 경로가 생김:

1. `EventService.performRequest`의 경우, `HTTPClient.post`가 completion을 안 부르면 `EventQueue.addEvent`의 `done()`도 호출되지 않는다. `EventQueue`는 직렬 큐라서 한 번 멈추면 그 뒤에 쌓이는 모든 이벤트·폴링 작업이 영구 정지.
2. `DeviceService.initializeDevice`의 경우, `BluxClient.initialize`의 completion이 영원히 pending 상태로 남는다. `isActivated=true`가 고정되고, 지난 PR(#78)에서 추가한 failure 롤백 경로도 콜백이 안 오니 발동하지 않는 이중 교착.

트리거 조건이 좁긴 하다(clientId UserDefaults write가 먹었는데 read에서 nil이 나오는 App Group 오설정 정도, 또는 URL 파싱 실패). 실환경 재현은 드물지만, 한 번 걸리면 앱 재시작 전까지 SDK가 조용히 먹통이 되는 유형이라 방어가 필요.

## 뭘 고쳤나

1. `HTTPError`에 `invalidRequest` case 추가하고, 4개 메서드의 `guard else` 분기에서 `completion(nil, .invalidRequest)`를 호출해 호출부의 error 경로가 정상 진입하도록 수정. 기존 error 핸들러들은 모두 이 경로에 안전하게 fall-through된다.
2. `EventService`는 `invalidRequest` 에러를 **재시도 불가(non-retryable)** 로 취급. 이 에러는 서버 응답이 아닌 로컬 preflight 실패라서 그대로 폴링 백오프를 재스케줄하면 같은 실패가 무한 반복되며 `cachedPollDelayMs`만 키움. 로그만 남기고 `done()` 후 종료.
3. `HTTPError` enum 가시성을 `private`에서 internal로 승격. EventService가 `if case HTTPClient.HTTPError.invalidRequest = error`로 분기하기 위해 필요. 외부 공개 API가 아닌 클래스 내부 타입이라 하위호환 영향 없음.

수정 범위: `BluxClient/Classes/HTTPClient.swift`, `BluxClient/Classes/EventService.swift`.

# Tests you conducted

Debug-stg 빌드 + iPhone 17 Pro 시뮬레이터(iOS 26.0) + `api.blux.ai/stg` + MongoDB dev에서 회귀 E2E.

- 정상 경로(Initialize → SignIn → Send Custom Event → SignOut) 전체 흐름에서 `blux_users` 생성, device merge, `custom_event_properties` 반영, anonymous user 재발급 모두 서버 side effect 확인.
- 이 변경은 정상 경로에선 no-op(guard else가 타지 않음). 회귀 없음.

**실패 경로 직접 트리거는 E2E로 재현 난이도가 높음(App Group 오설정 등)** — 이 부분은 코드 리뷰와 호출부 전수 점검으로 대체. 호출부(`EventService`, `DeviceService`, `BluxClient.signIn/signOut/setUserProperties*`, `BluxNotification.trackOpened/trackReceived`, `InappService.createInappOpened/createReceived`) 모두 error 분기에서 안전하게 fall-through되는 것 확인.

# ⛑ QA Test Cases

- [x] 테스트가 필요 없습니다 (체크하면 QA 라벨이 자동으로 추가되지 않습니다.)