### PR TITLE
fix: 이벤트 폴링 백오프 상한을 의도대로 1일로 정정

### DIFF
--- a/BluxClient/Classes/EventService.swift
+++ b/BluxClient/Classes/EventService.swift
@@ -107,8 +107,11 @@ class EventService {
                     if case HTTPClient.HTTPError.invalidRequest = error {
                         return
                     }
-                    // 실패 시 지수 백오프
-                    let nextPollDelay = cachedPollDelayMs > 1000 * 60 * 60 * 24 ? cachedPollDelayMs : cachedPollDelayMs * 2
+                    // 실패 시 지수 백오프 (24h 미만 구간에서만 2배, 상한 1일)
+                    let dayCapMs = 1000 * 60 * 60 * 24
+                    let nextPollDelay = cachedPollDelayMs >= dayCapMs
+                        ? cachedPollDelayMs
+                        : min(cachedPollDelayMs * 2, dayCapMs)
                     cachedPollDelayMs = nextPollDelay
                     scheduleNextPoll(delayMs: nextPollDelay)
                     return


### PR DESCRIPTION
# 📝 Changes

## 무슨 문제였나

`EventService`의 이벤트 전송 실패 시 지수 백오프가 **의도한 24시간 상한이 아니라 실제로는 48시간까지 늘어나는 off-by-one 버그**.

기존 조건:
```swift
let nextPollDelay = cachedPollDelayMs > 1000 * 60 * 60 * 24
  ? cachedPollDelayMs
  : cachedPollDelayMs * 2
```

"24시간 초과일 때만 증가 중단"이라서, 직전 값 12h → 24h까지는 2배로 증가하고, 24h에서도 조건이 `24h > 24h` = false라 한 번 더 곱해져서 **48h**까지 가서야 멈춤.

Web SDK(`packages/sdk-web/src/BluxClient.ts`)도 같은 구조로 동일한 버그. 반면 Android(`EventService.kt`)는 `(currentDelayMs * 2).coerceAtMost(24 * 60 * 60 * 1000L)`에 `// 최대 1일` 주석까지 달려있어, **세 SDK 공통 의도가 24시간 상한**임이 명확. 커밋 이력(Web `41411fa9` "서버에서 에러 발생 시 무한루프 없고 점점 polling 간격 늘어나도록", iOS `84f5cb9` 동일 로직 포팅, Android의 `9040c3e`에서 지워진 `// 최대 1일` 주석)에서도 확인됨.

## 뭘 고쳤나

```swift
let dayCapMs = 1000 * 60 * 60 * 24
let nextPollDelay = cachedPollDelayMs >= dayCapMs
    ? cachedPollDelayMs
    : min(cachedPollDelayMs * 2, dayCapMs)
```

- **24h 미만 구간**: 2배로 증가시키되 `min(..., 24h)`로 정확히 24h에서 clamp. 기존 48h로 튀는 off-by-one 제거.
- **24h 이상 구간**: 기존 값 유지. 이는 원본 조건문의 ">24h 유지" 시맨틱을 보존하기 위한 것. 서버가 `DISABLED_POLL_DELAY = 10일` 같은 긴 값을 의도적으로 돌려준 경우, 단 한 번의 네트워크 에러로 10일 → 24h로 줄어들어 서버 의도가 깨지는 회귀를 막는다.
- **부수 효과**: `cachedPollDelayMs * 2` 곱셈이 24h 미만 구간에서만 실행되므로 결과가 `(24h - 1) * 2 ≈ 48h` 이하로 bound. 서버가 비정상적으로 큰 `nextPollDelayMs`를 돌려주더라도 Swift `Int` 곱셈 overflow trap 경로가 제거된다.

## Android/Web은?

Android(`coerceAtMost(24h)`)와 Web(이 PR 이전 iOS와 동일 구조)는 별도 PR로 포팅 권장. 특히 Android는 현재 동작이 10일 → 24h 단축시키므로 iOS와 같은 ">24h 유지" 시맨틱으로 맞추면 일관성 개선.

# Tests you conducted

Debug-stg 빌드 + iPhone 17 Pro 시뮬레이터(iOS 26.0) + `api.blux.ai/stg` + MongoDB dev에서 회귀 E2E.

- 정상 경로(Initialize → SignIn → Send Custom Event → SignOut) 전체 흐름 동작 확인. 이 변경은 에러 경로에서만 활성화되므로 정상 경로에 영향 없음.

**실패 경로의 시간 기반 백오프 관찰은 E2E로 재현 어려움** (24h 단위, `cachedPollDelayMs`가 `private static`이라 외부 관찰 불가). 대신 Android/Web 원본 의도, 커밋 이력, 서버의 `DISABLED_POLL_DELAY` 사용 케이스를 교차 검증해 로직 시맨틱 확정.

# ⛑ QA Test Cases

- [x] 테스트가 필요 없습니다 (체크하면 QA 라벨이 자동으로 추가되지 않습니다.)