### PR TITLE
test: 단위/contract 테스트 + SPM testTarget + CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,15 +117,39 @@ jobs:
           set -o pipefail
           xcodebuild -workspace Example/BluxExample.xcworkspace -scheme BluxExample -destination 'generic/platform=iOS Simulator' CODE_SIGNING_ALLOWED=NO build
 
-      - name: Build Swift package (SPM)
+      - name: Build & test Swift package (SPM)
         run: |
           set -o pipefail
           rm -rf .ci-spm-build
           mkdir -p .ci-spm-build
           cp Package.swift .ci-spm-build/
           cp -R BluxClient .ci-spm-build/
+          cp -R Tests .ci-spm-build/
           cd .ci-spm-build
-          xcodebuild -scheme BluxClient -destination 'generic/platform=iOS' CODE_SIGNING_ALLOWED=NO build
+
+          # arm64 device triple 빌드 검증. 시뮬레이터(arm64-simulator)와 triple이 달라
+          # device-only 컴파일 break를 따로 잡아준다.
+          xcodebuild -scheme BluxClient \
+            -destination 'generic/platform=iOS' \
+            CODE_SIGNING_ALLOWED=NO build
+
+          # macos runner에 사전 설치된 첫 iPhone iOS 시뮬레이터를 동적으로 선택해
+          # iPhone 모델/OS 버전 hardcode 없이 미래 runner에서도 그대로 동작.
+          SIMULATOR_ID=$(xcrun simctl list devices available -j \
+            | jq -r '[.devices | to_entries[]
+                      | select(.key | test("iOS"))
+                      | .value[]
+                      | select(.name | startswith("iPhone"))]
+                     | first | .udid')
+          if [ -z "$SIMULATOR_ID" ] || [ "$SIMULATOR_ID" = "null" ]; then
+            echo "No available iPhone Simulator found"
+            xcrun simctl list devices available
+            exit 1
+          fi
+          echo "Using simulator: $SIMULATOR_ID"
+          xcodebuild -scheme BluxClient \
+            -destination "id=$SIMULATOR_ID" \
+            CODE_SIGNING_ALLOWED=NO test
 
       - name: Lint podspec
         run: bundle exec pod lib lint BluxClient.podspec --allow-warnings --skip-tests --verbose

--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,11 @@ DerivedData
 .swiftpm/
 .swiftpm-cache/
 
+# Swift compiler intermediate outputs (when build is misrouted to repo root)
+*.d
+*.dia
+*.swiftdeps
+
 # Add this line if you want to avoid checking in source code from Carthage dependencies.
 # Carthage/Checkouts
 

--- a/BluxClient/Classes/BluxWebSdkBridge.swift
+++ b/BluxClient/Classes/BluxWebSdkBridge.swift
@@ -51,14 +51,17 @@ public final class BluxWebSdkBridge: NSObject {
 extension BluxWebSdkBridge: WKScriptMessageHandler {
     public func userContentController(_: WKUserContentController, didReceive message: WKScriptMessage) {
         guard message.name == BluxWebSdkBridge.handlerName else { return }
+        handle(scriptMessageBody: message.body)
+    }
 
+    func handle(scriptMessageBody body: Any) {
         let json: [String: Any]?
-        if let str = message.body as? String,
+        if let str = body as? String,
            let data = str.data(using: .utf8),
            let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
         {
             json = obj
-        } else if let obj = message.body as? [String: Any] {
+        } else if let obj = body as? [String: Any] {
             json = obj
         } else {
             Logger.error("BluxWebSdkBridge: invalid message format")

--- a/Package.swift
+++ b/Package.swift
@@ -17,8 +17,20 @@ let package = Package(
             name: "BluxClient",
             path: "BluxClient/Classes",
             exclude: [".gitkeep"]
+        ),
+        .testTarget(
+            name: "BluxClientTests",
+            dependencies: ["BluxClient"],
+            path: "Tests/BluxClientTests"
+        ),
+        // Public API surface는 wrapper SDK(RN/Flutter)와 동일한 access modifier로 검증한다.
+        // BluxClientTests는 @testable import라 internal까지 보이므로 public→internal 강등 회귀를
+        // 잡지 못한다. 이 testTarget은 plain `import BluxClient`만 쓰는 별도 모듈로 격리.
+        .testTarget(
+            name: "BluxClientPublicAPITests",
+            dependencies: ["BluxClient"],
+            path: "Tests/BluxClientPublicAPITests"
         )
     ],
     swiftLanguageVersions: [.v5]
 )
-

--- a/Tests/BluxClientPublicAPITests/PublicAPISurfaceTests.swift
+++ b/Tests/BluxClientPublicAPITests/PublicAPISurfaceTests.swift
@@ -1,0 +1,99 @@
+import XCTest
+import UIKit
+import WebKit
+import BluxClient
+
+/// wrapper SDK(RN/Flutter)가 import하는 것과 동일한 plain `import BluxClient`로 작성.
+/// public→internal 강등 같은 access-control 회귀가 BluxClientTests(@testable)를 통과하더라도
+/// 이 타겟은 컴파일 실패해 회귀를 잡는다.
+///
+/// 모든 검증은 컴파일 시점. method/type reference로 시그니처를 잡으면 되며 실제 호출은 불필요.
+final class PublicAPISurfaceTests: XCTestCase {
+    func testBluxClientPublicMethodSignaturesCompile() {
+        let _: ([UIApplication.LaunchOptionsKey: Any]?, String, String, Bool, String?, @escaping ((NSError?) -> Void)) -> Void
+            = BluxClient.initialize(_:bluxApplicationId:bluxAPIKey:requestPermissionOnLaunch:customDeviceId:completion:)
+
+        let _: (LogLevel) -> Void = BluxClient.setLogLevel(level:)
+
+        let _: (String, @escaping ((NSError?) -> Void)) -> Void = BluxClient.signIn(userId:completion:)
+
+        let _: () -> Void = BluxClient.signOut
+
+        let _: ([String: Any?]) -> Void = BluxClient.setUserPropertiesData(userProperties:)
+
+        let _: (UserProperties) -> Void = BluxClient.setUserProperties(userProperties:)
+
+        let _: ([String: Any?]) -> Void = BluxClient.setCustomUserProperties(customUserProperties:)
+
+        let _: ([Event]) -> Void = BluxClient.sendRequestData
+
+        let _: (EventRequest) -> Void = BluxClient.sendEvent
+
+        let _: (NotificationUrlOpenOptions) -> Void = BluxClient.setNotificationUrlOpenOptions
+
+        let _: () -> Void = BluxClient.dismissInApp
+
+        let _: (@escaping (BluxNotification) -> Void) -> Void = BluxClient.setNotificationClickedHandler(callback:)
+
+        let _: (@escaping (NotificationReceivedEvent) -> Void) -> Void
+            = BluxClient.setNotificationForegroundWillDisplayHandler(callback:)
+
+        let _: (@escaping (String, [String: Any]) -> Void) -> () -> Void
+            = BluxClient.addInAppCustomActionHandler(callback:)
+    }
+
+    func testPublicTypeMembersCompile() {
+        // Event public init과 mutable capturedAt
+        let event = Event(eventType: "x")
+        event.capturedAt = "2025-01-01T00:00:00.000Z"
+
+        // Event 체인 메서드는 public
+        let _: (EventProperties?) -> Event = event.setEventProperties
+        let _: ([String: CustomEventValue]?) -> Event = event.setCustomEventProperties
+        let _: ([String: CustomEventValue]?) -> Event = event.setInternalEventProperties
+
+        // EventProperties는 wrapper SDK에서 JSONDecoder로만 생성하므로 직접 init() 검증은 하지 않는다.
+        // (현재 EventProperties는 명시적 public init이 없어 wrapper 모듈에서 직접 init 불가.
+        //  Codable witness를 통한 디코딩만 가능.)
+        let _ = try? JSONDecoder().decode(EventProperties.self, from: Data("{}".utf8))
+
+        // UserProperties는 public init으로 wrapper SDK가 직접 생성한다 (Flutter 패턴).
+        let _ = UserProperties()
+        let _ = UserProperties(phoneNumber: "x")
+        let _ = UserProperties(age: 1)
+        let _ = UserProperties(gender: .male)
+
+        // CustomEventValue.fromAny public
+        let _: CustomEventValue? = CustomEventValue.fromAny("x")
+
+        // BluxNotification public init
+        let _ = BluxNotification(id: "x", body: "y", title: nil, url: nil, imageUrl: nil, data: nil)
+
+        // LogLevel cases
+        let _: LogLevel = .verbose
+        let _: LogLevel = .error
+        let _: LogLevel = .none
+    }
+
+    func testHttpUrlOpenTargetMembersAccessible() {
+        let _: HttpUrlOpenTarget = .internalWebView
+        let _: HttpUrlOpenTarget = .externalBrowser
+        let _: HttpUrlOpenTarget = HttpUrlOpenTarget.none
+    }
+
+    func testBluxWebSdkBridgePublicSignaturesCompile() {
+        // wrapper SDK에서 import해 호출하므로 시그니처는 public으로 유지돼야 한다.
+        // WKWebView 인스턴스화는 시뮬레이터 GPU 초기화를 트리거해 후속 테스트를 stall시키므로
+        // 메서드 참조만 잡아 컴파일 타임에 시그니처를 락-인한다 (실제 호출은 안 함).
+        let _: String = BluxWebSdkBridge.handlerName
+        let _: (WKWebView) -> BluxWebSdkBridge = BluxWebSdkBridge.attach(to:)
+        let _: (WKWebView) -> Void = BluxWebSdkBridge.detach(from:)
+    }
+
+    func testStageSwitcherIsAccessibleViaObjCRuntime() {
+        // RN/Flutter SDK는 StageSwitcher를 NSClassFromString("BluxStageSwitcher")로 호출 가능해야 함.
+        // (`@objc(BluxStageSwitcher)` runtime 노출 검증)
+        let cls: AnyClass? = NSClassFromString("BluxStageSwitcher")
+        XCTAssertNotNil(cls)
+    }
+}

--- a/Tests/BluxClientTests/BluxClientTests.swift
+++ b/Tests/BluxClientTests/BluxClientTests.swift
@@ -67,7 +67,6 @@ final class BluxClientTests: XCTestCase {
     // MARK: - signOut 사전조건
 
     func testSignOutDoesNotCrashWhenNoIds() {
-        // IDs 없을 때도 EventHandlers/EventService/InappService cleanup은 무조건 일어남
         EventHandlers.unhandledNotification = BluxNotification(
             id: "n", body: "B", title: nil, url: nil, imageUrl: nil, data: nil
         )
@@ -79,15 +78,12 @@ final class BluxClientTests: XCTestCase {
     // MARK: - setUserPropertiesData / setCustomUserProperties 사전조건
 
     func testSetUserPropertiesDataReturnsEarlyWhenNoIds() {
-        // 사전조건 미충족이면 그냥 return. 크래시만 없으면 통과.
         BluxClient.setUserPropertiesData(userProperties: ["k": "v"])
     }
 
     func testSetUserPropertiesPassesGenderAsRawString() {
-        // 내부적으로 setUserPropertiesData를 호출. 사전조건 미충족으로 return.
         let props = UserProperties(age: 30, gender: .female)
         BluxClient.setUserProperties(userProperties: props)
-        // 검증: 크래시 없이 통과
     }
 
     func testSetCustomUserPropertiesReturnsEarlyWhenNoIds() {
@@ -161,21 +157,4 @@ final class BluxClientTests: XCTestCase {
         BluxClient.dismissInApp()
     }
 
-    // MARK: - credential 변경 감지
-
-    // API key만 교체된 경우에도 credentialsChanged=true로 인식되어 cleanup 실행.
-    // (회귀: apiKeyInUserDefaults를 쓰기 전에 savedApiKey를 읽어야 함)
-    func testInitializeDetectsApiKeyOnlyChangeAsCredentialChange() {
-        SdkConfig.clientIdInUserDefaults = "app-1"
-        SdkConfig.apiKeyInUserDefaults = "key-old"
-        EventHandlers.unhandledNotification = BluxNotification(
-            id: "leak", body: "B", title: nil, url: nil, imageUrl: nil, data: nil
-        )
-
-        BluxClient.initialize(nil, bluxApplicationId: "app-1", bluxAPIKey: "key-NEW") { _ in }
-
-        XCTAssertEqual(SdkConfig.apiKeyInUserDefaults, "key-NEW")
-        XCTAssertNil(EventHandlers.unhandledNotification,
-                     "API key 변경만으로도 credentialsChanged=true가 되어 cleanup 발생해야 함")
-    }
 }

--- a/Tests/BluxClientTests/BluxClientTests.swift
+++ b/Tests/BluxClientTests/BluxClientTests.swift
@@ -1,0 +1,181 @@
+import XCTest
+@testable import BluxClient
+
+/// BluxClient의 정적 API 일부 동작을 검증.
+/// 네트워크가 필요한 경로는 모킹 불가하므로 사전조건 분기와 핸들러 등록만 검증.
+final class BluxClientTests: XCTestCase {
+    private var guardian: SdkStateGuard!
+
+    override func setUp() {
+        super.setUp()
+        guardian = SdkStateGuard()
+        guardian.clear()
+    }
+
+    override func tearDown() {
+        guardian.restore()
+        guardian = nil
+        super.tearDown()
+    }
+
+    // MARK: - setLogLevel
+
+    func testSetLogLevelChangesConfig() {
+        let saved = SdkConfig.logLevel
+        defer { SdkConfig.logLevel = saved }
+
+        BluxClient.setLogLevel(level: .none)
+        XCTAssertEqual(SdkConfig.logLevel, .none)
+
+        BluxClient.setLogLevel(level: .error)
+        XCTAssertEqual(SdkConfig.logLevel, .error)
+
+        BluxClient.setLogLevel(level: .verbose)
+        XCTAssertEqual(SdkConfig.logLevel, .verbose)
+    }
+
+    // MARK: - setNotificationUrlOpenOptions
+
+    func testSetNotificationUrlOpenOptionsPersists() {
+        BluxClient.setNotificationUrlOpenOptions(
+            NotificationUrlOpenOptions(httpUrlOpenTarget: .externalBrowser)
+        )
+        XCTAssertEqual(SdkConfig.notificationUrlOpenOptions.httpUrlOpenTarget, .externalBrowser)
+
+        BluxClient.setNotificationUrlOpenOptions(
+            NotificationUrlOpenOptions(httpUrlOpenTarget: .none)
+        )
+        XCTAssertEqual(SdkConfig.notificationUrlOpenOptions.httpUrlOpenTarget, .none)
+    }
+
+    // MARK: - signIn 사전조건
+
+    func testSignInFailsFastWhenNoIds() {
+        let exp = expectation(description: "signIn early-fail")
+        var capturedError: NSError?
+
+        BluxClient.signIn(userId: "u") { error in
+            capturedError = error
+            exp.fulfill()
+        }
+
+        wait(for: [exp], timeout: 2.0)
+        XCTAssertNotNil(capturedError)
+        XCTAssertEqual(capturedError?.domain, "BluxClient")
+    }
+
+    // MARK: - signOut 사전조건
+
+    func testSignOutDoesNotCrashWhenNoIds() {
+        // IDs 없을 때도 EventHandlers/EventService/InappService cleanup은 무조건 일어남
+        EventHandlers.unhandledNotification = BluxNotification(
+            id: "n", body: "B", title: nil, url: nil, imageUrl: nil, data: nil
+        )
+        BluxClient.signOut()
+        XCTAssertNil(EventHandlers.unhandledNotification,
+                     "signOut must clear unhandled notification regardless of IDs")
+    }
+
+    // MARK: - setUserPropertiesData / setCustomUserProperties 사전조건
+
+    func testSetUserPropertiesDataReturnsEarlyWhenNoIds() {
+        // 사전조건 미충족이면 그냥 return. 크래시만 없으면 통과.
+        BluxClient.setUserPropertiesData(userProperties: ["k": "v"])
+    }
+
+    func testSetUserPropertiesPassesGenderAsRawString() {
+        // 내부적으로 setUserPropertiesData를 호출. 사전조건 미충족으로 return.
+        let props = UserProperties(age: 30, gender: .female)
+        BluxClient.setUserProperties(userProperties: props)
+        // 검증: 크래시 없이 통과
+    }
+
+    func testSetCustomUserPropertiesReturnsEarlyWhenNoIds() {
+        BluxClient.setCustomUserProperties(customUserProperties: ["k": "v"])
+    }
+
+    // MARK: - Notification 핸들러 등록
+
+    func testSetNotificationClickedHandlerStoresHandler() {
+        var fired = false
+        BluxClient.setNotificationClickedHandler { _ in fired = true }
+        XCTAssertNotNil(EventHandlers.notificationClicked)
+
+        let n = BluxNotification(id: "n", body: "B", title: nil, url: nil, imageUrl: nil, data: nil)
+        EventHandlers.notificationClicked?(n)
+        XCTAssertTrue(fired)
+    }
+
+    func testSetNotificationClickedHandlerProcessesUnhandledImmediately() {
+        let pendingNotif = BluxNotification(
+            id: "pending", body: "B", title: nil, url: nil, imageUrl: nil, data: nil
+        )
+        EventHandlers.unhandledNotification = pendingNotif
+
+        var receivedId: String?
+        BluxClient.setNotificationClickedHandler { n in receivedId = n.id }
+
+        XCTAssertEqual(receivedId, "pending",
+                       "Pending unhandled notification must fire upon registration")
+        XCTAssertNil(EventHandlers.unhandledNotification,
+                     "Unhandled notification must be cleared after firing")
+    }
+
+    func testSetNotificationForegroundWillDisplayHandlerStoresHandler() {
+        BluxClient.setNotificationForegroundWillDisplayHandler { _ in }
+        XCTAssertNotNil(EventHandlers.notificationForegroundWillDisplay)
+    }
+
+    // MARK: - addInAppCustomActionHandler
+
+    func testAddInAppCustomActionHandlerReturnsUnsubscribeFunction() {
+        let unsubscribe = BluxClient.addInAppCustomActionHandler { _, _ in }
+        XCTAssertEqual(EventHandlers.inAppCustomActionHandlers.count, 1)
+        unsubscribe()
+        XCTAssertEqual(EventHandlers.inAppCustomActionHandlers.count, 0)
+    }
+
+    func testMultipleHandlersCanCoexist() {
+        let u1 = BluxClient.addInAppCustomActionHandler { _, _ in }
+        let u2 = BluxClient.addInAppCustomActionHandler { _, _ in }
+        XCTAssertEqual(EventHandlers.inAppCustomActionHandlers.count, 2)
+        u1()
+        u2()
+    }
+
+    // MARK: - sendEvent / sendRequestData 호환성
+
+    func testSendEventWithEventRequestDoesNotCrash() {
+        let req = EventRequest()
+        req.events.append(Event(eventType: "x"))
+        BluxClient.sendEvent(req)
+    }
+
+    func testSendRequestDataWithEmptyArrayDoesNotCrash() {
+        BluxClient.sendRequestData([])
+    }
+
+    // MARK: - dismissInApp
+
+    func testDismissInAppDoesNotCrashWhenNothingShown() {
+        BluxClient.dismissInApp()
+    }
+
+    // MARK: - credential 변경 감지
+
+    // API key만 교체된 경우에도 credentialsChanged=true로 인식되어 cleanup 실행.
+    // (회귀: apiKeyInUserDefaults를 쓰기 전에 savedApiKey를 읽어야 함)
+    func testInitializeDetectsApiKeyOnlyChangeAsCredentialChange() {
+        SdkConfig.clientIdInUserDefaults = "app-1"
+        SdkConfig.apiKeyInUserDefaults = "key-old"
+        EventHandlers.unhandledNotification = BluxNotification(
+            id: "leak", body: "B", title: nil, url: nil, imageUrl: nil, data: nil
+        )
+
+        BluxClient.initialize(nil, bluxApplicationId: "app-1", bluxAPIKey: "key-NEW") { _ in }
+
+        XCTAssertEqual(SdkConfig.apiKeyInUserDefaults, "key-NEW")
+        XCTAssertNil(EventHandlers.unhandledNotification,
+                     "API key 변경만으로도 credentialsChanged=true가 되어 cleanup 발생해야 함")
+    }
+}

--- a/Tests/BluxClientTests/BluxDeviceTests.swift
+++ b/Tests/BluxClientTests/BluxDeviceTests.swift
@@ -1,0 +1,235 @@
+import XCTest
+@testable import BluxClient
+
+/// BluxDeviceInfo는 서버 initialize/sign-in/sign-out body 및 update push token body와 매칭.
+/// 핵심: pushToken은 nil이어도 서버에 명시적으로 null로 전송돼야 함 (push token 제거 의도 표현).
+/// userId도 nil이면 명시적 null (서버 기록).
+final class BluxDeviceTests: XCTestCase {
+    private var guardian: SdkStateGuard!
+    private let encoder = JSONEncoder()
+    private let decoder = JSONDecoder()
+
+    override func setUp() {
+        super.setUp()
+        guardian = SdkStateGuard()
+        guardian.clear()
+    }
+
+    override func tearDown() {
+        guardian.restore()
+        guardian = nil
+        super.tearDown()
+    }
+
+    // MARK: - BluxDeviceResponse decoding
+
+    func testBluxDeviceResponseDecodesSnakeCase() throws {
+        let json = """
+        { "blux_user_id": "B-1", "device_id": "D-1" }
+        """.data(using: .utf8)!
+        let response = try decoder.decode(BluxDeviceResponse.self, from: json)
+        XCTAssertEqual(response.bluxId, "B-1")
+        XCTAssertEqual(response.deviceId, "D-1")
+    }
+
+    func testBluxDeviceResponseDecodesWithoutDeviceId() throws {
+        let json = "{ \"blux_user_id\": \"B-1\" }".data(using: .utf8)!
+        let response = try decoder.decode(BluxDeviceResponse.self, from: json)
+        XCTAssertEqual(response.bluxId, "B-1")
+        XCTAssertNil(response.deviceId)
+    }
+
+    func testBluxDeviceResponseRequiresBluxUserId() {
+        let json = "{ \"device_id\": \"D-1\" }".data(using: .utf8)!
+        XCTAssertThrowsError(try decoder.decode(BluxDeviceResponse.self, from: json))
+    }
+
+    // MARK: - BluxDeviceInfo encoding (snake_case keys & explicit null fields)
+
+    func testEncodesAllRequiredFieldsWithSnakeCase() throws {
+        let info = BluxDeviceInfo(
+            platform: "ios",
+            deviceModel: "iPhone17,1",
+            osVersion: "18.0",
+            sdkVersion: "1.2.3",
+            timezone: "Asia/Seoul",
+            languageCode: "ko",
+            countryCode: "KR",
+            sdkType: "native"
+        )
+        let data = try encoder.encode(info)
+        let dict = try JSONSerialization.jsonObject(with: data) as! [String: Any]
+
+        XCTAssertEqual(dict["platform"] as? String, "ios")
+        XCTAssertEqual(dict["device_model"] as? String, "iPhone17,1")
+        XCTAssertEqual(dict["os_version"] as? String, "18.0")
+        XCTAssertEqual(dict["sdk_version"] as? String, "1.2.3")
+        XCTAssertEqual(dict["timezone"] as? String, "Asia/Seoul")
+        XCTAssertEqual(dict["language_code"] as? String, "ko")
+        XCTAssertEqual(dict["country_code"] as? String, "KR")
+        XCTAssertEqual(dict["sdk_type"] as? String, "native")
+    }
+
+    func testEncodesPushTokenAsExplicitNullWhenNil() throws {
+        let info = BluxDeviceInfo(
+            platform: "ios",
+            deviceModel: "X",
+            osVersion: "0",
+            sdkVersion: "0",
+            timezone: "UTC",
+            languageCode: nil,
+            countryCode: nil,
+            sdkType: "native"
+        )
+        info.pushToken = nil
+
+        let data = try encoder.encode(info)
+        // JSON에 push_token 키가 명시적으로 null로 존재해야 함 (서버 contract: null로 push token 제거)
+        let raw = String(data: data, encoding: .utf8)!
+        XCTAssertTrue(raw.contains("\"push_token\":null"),
+                      "push_token must be explicitly null. Got: \(raw)")
+    }
+
+    func testEncodesPushTokenWhenSet() throws {
+        let info = BluxDeviceInfo(
+            pushToken: "abc123",
+            platform: "ios",
+            deviceModel: "X",
+            osVersion: "0",
+            sdkVersion: "0",
+            timezone: "UTC",
+            languageCode: nil,
+            countryCode: nil,
+            sdkType: "native"
+        )
+        let data = try encoder.encode(info)
+        let dict = try JSONSerialization.jsonObject(with: data) as! [String: Any]
+        XCTAssertEqual(dict["push_token"] as? String, "abc123")
+    }
+
+    func testEncodesUserIdAsExplicitNullWhenNil() throws {
+        let info = BluxDeviceInfo(
+            platform: "ios",
+            deviceModel: "X",
+            osVersion: "0",
+            sdkVersion: "0",
+            timezone: "UTC",
+            languageCode: nil,
+            countryCode: nil,
+            sdkType: "native"
+        )
+        // userId는 SdkConfig.userIdInUserDefaults를 따라가는데 setUp에서 비웠으니 nil
+        XCTAssertNil(info.userId)
+
+        let data = try encoder.encode(info)
+        let raw = String(data: data, encoding: .utf8)!
+        XCTAssertTrue(raw.contains("\"user_id\":null"),
+                      "user_id must be explicitly null when not signed in. Got: \(raw)")
+    }
+
+    func testEncodesUserIdWhenSdkConfigSet() throws {
+        SdkConfig.userIdInUserDefaults = "user-9"
+
+        let info = BluxDeviceInfo(
+            platform: "ios",
+            deviceModel: "X",
+            osVersion: "0",
+            sdkVersion: "0",
+            timezone: "UTC",
+            languageCode: nil,
+            countryCode: nil,
+            sdkType: "native"
+        )
+        let data = try encoder.encode(info)
+        let dict = try JSONSerialization.jsonObject(with: data) as! [String: Any]
+        XCTAssertEqual(dict["user_id"] as? String, "user-9")
+    }
+
+    func testEncodingExplicitlyNullsBluxIdButOmitsDeviceIdWhenNil() throws {
+        let info = BluxDeviceInfo(
+            platform: "ios",
+            deviceModel: "X",
+            osVersion: "0",
+            sdkVersion: "0",
+            timezone: "UTC",
+            languageCode: nil,
+            countryCode: nil,
+            sdkType: "native"
+        )
+        let data = try encoder.encode(info)
+        let raw = String(data: data, encoding: .utf8)!
+
+        // bluxId는 try container.encode(bluxId, forKey:) 직접 호출 → nil이면 명시적 null로 인코딩됨
+        XCTAssertTrue(raw.contains("\"blux_id\":null"),
+                      "blux_id should be explicit null. Got: \(raw)")
+        // deviceId는 if-let 가드 후 encode → nil이면 키 자체가 빠짐
+        XCTAssertFalse(raw.contains("device_id"),
+                       "device_id key should be absent when nil. Got: \(raw)")
+    }
+
+    func testEncodesOptionalFieldsWhenPresent() throws {
+        let info = BluxDeviceInfo(
+            platform: "ios",
+            deviceModel: "X",
+            osVersion: "0",
+            sdkVersion: "0",
+            timezone: "UTC",
+            languageCode: "ko",
+            countryCode: "KR",
+            sdkType: "native",
+            sessionId: "S-1",
+            appVersion: "9.9.9"
+        )
+        info.customDeviceId = "CD"
+
+        let data = try encoder.encode(info)
+        let dict = try JSONSerialization.jsonObject(with: data) as! [String: Any]
+        XCTAssertEqual(dict["session_id"] as? String, "S-1")
+        XCTAssertEqual(dict["app_version"] as? String, "9.9.9")
+        XCTAssertEqual(dict["custom_device_id"] as? String, "CD")
+    }
+
+    func testInheritsSessionIdFromSdkConfigWhenInitNotProvided() {
+        SdkConfig.sessionId = "auto-S"
+        let info = BluxDeviceInfo(
+            platform: "ios",
+            deviceModel: "X",
+            osVersion: "0",
+            sdkVersion: "0",
+            timezone: "UTC",
+            languageCode: nil,
+            countryCode: nil,
+            sdkType: "native"
+        )
+        XCTAssertEqual(info.sessionId, "auto-S")
+    }
+
+    // MARK: - description
+
+    func testDescriptionContainsPresentFields() {
+        SdkConfig.bluxIdInUserDefaults = "B"
+        SdkConfig.deviceIdInUserDefaults = "D"
+        SdkConfig.userIdInUserDefaults = "U"
+
+        let info = BluxDeviceInfo(
+            pushToken: "T",
+            platform: "ios",
+            deviceModel: "X",
+            osVersion: "1.0",
+            sdkVersion: "0.0.1",
+            timezone: "Asia/Seoul",
+            languageCode: "ko",
+            countryCode: "KR",
+            sdkType: "native",
+            appVersion: "1.0"
+        )
+
+        let desc = info.description
+        XCTAssertTrue(desc.contains("bluxId: B"))
+        XCTAssertTrue(desc.contains("deviceId: D"))
+        XCTAssertTrue(desc.contains("userId: U"))
+        XCTAssertTrue(desc.contains("pushToken: T"))
+        XCTAssertTrue(desc.contains("platform: ios"))
+        XCTAssertTrue(desc.contains("countryCode: KR"))
+    }
+}

--- a/Tests/BluxClientTests/BluxErrorTests.swift
+++ b/Tests/BluxClientTests/BluxErrorTests.swift
@@ -1,0 +1,46 @@
+import XCTest
+@testable import BluxClient
+
+final class BluxErrorTests: XCTestCase {
+    func testLengthOutOfRangeBetween_ErrorDescription() {
+        let error = BluxError.LengthOutOfRangeBetween("name", 1, 10)
+        XCTAssertEqual(error.errorDescription, "The length of `name` must be between 1 and 10.")
+    }
+
+    func testLengthOutOfRangeGe_ErrorDescription() {
+        let error = BluxError.LengthOutOfRangeGe("page", 5)
+        XCTAssertEqual(error.errorDescription, "The length of `page` must be greater than or equal to 5.")
+    }
+
+    func testValueOutOfRangeBetween_ErrorDescription() {
+        let error = BluxError.ValueOutOfRangeBetween("price", 0.0, 100.0)
+        XCTAssertEqual(error.errorDescription, "The value of `price` must be between 0.0 and 100.0.")
+    }
+
+    func testValueOutOfRangeGe_ErrorDescription() {
+        let error = BluxError.ValueOutOfRangeGe("price", 0)
+        XCTAssertEqual(error.errorDescription, "The value of `price` must be greater than or equal to 0.")
+    }
+
+    func testInvalidQuantity_ErrorDescription() {
+        let error = BluxError.InvalidQuantity
+        XCTAssertEqual(error.errorDescription, "Purchase quantity must be greater than 0.")
+    }
+
+    func testIsLocalizedError() {
+        let error: Error = BluxError.InvalidQuantity
+        XCTAssertNotNil((error as? LocalizedError)?.errorDescription)
+    }
+
+    func testClientErrorHoldsMessageAndStatusCode() {
+        let clientError = BluxError.ClientError(message: "Bad Request", httpStatusCode: 400)
+        XCTAssertEqual(clientError.message, "Bad Request")
+        XCTAssertEqual(clientError.httpStatusCode, 400)
+    }
+
+    func testClientErrorOptionalFields() {
+        let clientError = BluxError.ClientError(message: nil, httpStatusCode: nil)
+        XCTAssertNil(clientError.message)
+        XCTAssertNil(clientError.httpStatusCode)
+    }
+}

--- a/Tests/BluxClientTests/BluxNotificationTests.swift
+++ b/Tests/BluxClientTests/BluxNotificationTests.swift
@@ -1,0 +1,200 @@
+import XCTest
+import UIKit
+@testable import BluxClient
+
+final class BluxNotificationTests: XCTestCase {
+    // MARK: - Init
+
+    func testInitAssignsAllProperties() {
+        let notif = BluxNotification(
+            id: "n1",
+            body: "Hello",
+            title: "Title",
+            url: "https://example.com",
+            imageUrl: "https://img.example.com/i.png",
+            data: ["foo": "bar"]
+        )
+        XCTAssertEqual(notif.id, "n1")
+        XCTAssertEqual(notif.body, "Hello")
+        XCTAssertEqual(notif.title, "Title")
+        XCTAssertEqual(notif.url, "https://example.com")
+        XCTAssertEqual(notif.imageUrl, "https://img.example.com/i.png")
+        XCTAssertEqual(notif.data?["foo"] as? String, "bar")
+    }
+
+    func testInitConvertsEmptyStringsToNil() {
+        let notif = BluxNotification(
+            id: "n1",
+            body: "Hello",
+            title: "",
+            url: "",
+            imageUrl: "",
+            data: nil
+        )
+        XCTAssertNil(notif.title)
+        XCTAssertNil(notif.url)
+        XCTAssertNil(notif.imageUrl)
+    }
+
+    func testInitNilStringsRemainNil() {
+        let notif = BluxNotification(
+            id: "n1",
+            body: "Hello",
+            title: nil,
+            url: nil,
+            imageUrl: nil,
+            data: nil
+        )
+        XCTAssertNil(notif.title)
+        XCTAssertNil(notif.url)
+        XCTAssertNil(notif.imageUrl)
+    }
+
+    // MARK: - getBluxNotificationFromUserInfo
+
+    private let validUserInfo: [AnyHashable: Any] = [
+        "isBlux": true,
+        "notificationId": "abc",
+        "aps": [
+            "alert": [
+                "body": "Hello body",
+                "title": "Hello title"
+            ]
+        ],
+        "url": "https://blux.ai",
+        "imageUrl": "https://img",
+        "data": ["k": "v"]
+    ]
+
+    func testGetFromUserInfoValid() {
+        let notif = BluxNotification.getBluxNotificationFromUserInfo(userInfo: validUserInfo)
+        XCTAssertNotNil(notif)
+        XCTAssertEqual(notif?.id, "abc")
+        XCTAssertEqual(notif?.body, "Hello body")
+        XCTAssertEqual(notif?.title, "Hello title")
+        XCTAssertEqual(notif?.url, "https://blux.ai")
+        XCTAssertEqual(notif?.imageUrl, "https://img")
+        XCTAssertEqual(notif?.data?["k"] as? String, "v")
+    }
+
+    func testGetFromUserInfoMissingIsBluxReturnsNil() {
+        var info = validUserInfo
+        info.removeValue(forKey: "isBlux")
+        XCTAssertNil(BluxNotification.getBluxNotificationFromUserInfo(userInfo: info))
+    }
+
+    func testGetFromUserInfoIsBluxFalseReturnsNil() {
+        var info = validUserInfo
+        info["isBlux"] = false
+        XCTAssertNil(BluxNotification.getBluxNotificationFromUserInfo(userInfo: info))
+    }
+
+    func testGetFromUserInfoMissingNotificationIdReturnsNil() {
+        var info = validUserInfo
+        info.removeValue(forKey: "notificationId")
+        XCTAssertNil(BluxNotification.getBluxNotificationFromUserInfo(userInfo: info))
+    }
+
+    func testGetFromUserInfoMissingApsReturnsNil() {
+        var info = validUserInfo
+        info.removeValue(forKey: "aps")
+        XCTAssertNil(BluxNotification.getBluxNotificationFromUserInfo(userInfo: info))
+    }
+
+    func testGetFromUserInfoMissingAlertReturnsNil() {
+        var info = validUserInfo
+        info["aps"] = ["badge": 1]
+        XCTAssertNil(BluxNotification.getBluxNotificationFromUserInfo(userInfo: info))
+    }
+
+    func testGetFromUserInfoMissingBodyReturnsNil() {
+        var info = validUserInfo
+        info["aps"] = ["alert": ["title": "T"]]
+        XCTAssertNil(BluxNotification.getBluxNotificationFromUserInfo(userInfo: info))
+    }
+
+    func testGetFromUserInfoOptionalFieldsCanBeMissing() {
+        let minimal: [AnyHashable: Any] = [
+            "isBlux": true,
+            "notificationId": "id",
+            "aps": ["alert": ["body": "B"]]
+        ]
+        let notif = BluxNotification.getBluxNotificationFromUserInfo(userInfo: minimal)
+        XCTAssertNotNil(notif)
+        XCTAssertNil(notif?.title)
+        XCTAssertNil(notif?.url)
+        XCTAssertNil(notif?.imageUrl)
+        XCTAssertNil(notif?.data)
+    }
+
+    func testGetFromUserInfoEmptyTitleBecomesNil() {
+        var info = validUserInfo
+        info["aps"] = ["alert": ["body": "B", "title": ""]]
+        let notif = BluxNotification.getBluxNotificationFromUserInfo(userInfo: info)
+        XCTAssertNotNil(notif)
+        XCTAssertNil(notif?.title)
+    }
+
+    // MARK: - getBluxNotificationFromLaunchOptions
+
+    func testGetFromLaunchOptionsNilReturnsNil() {
+        let result = BluxNotification.getBluxNotificationFromLaunchOptions(launchOptions: nil)
+        XCTAssertNil(result)
+    }
+
+    func testGetFromLaunchOptionsWithoutRemoteNotificationReturnsNil() {
+        let opts: [UIApplication.LaunchOptionsKey: Any] = [
+            .url: URL(string: "blux://test")!
+        ]
+        XCTAssertNil(BluxNotification.getBluxNotificationFromLaunchOptions(launchOptions: opts))
+    }
+
+    func testGetFromLaunchOptionsValidPayload() {
+        let payload: [String: Any] = [
+            "isBlux": true,
+            "notificationId": "n",
+            "aps": ["alert": ["body": "B"]]
+        ]
+        let opts: [UIApplication.LaunchOptionsKey: Any] = [
+            .remoteNotification: payload
+        ]
+        let notif = BluxNotification.getBluxNotificationFromLaunchOptions(launchOptions: opts)
+        XCTAssertNotNil(notif)
+        XCTAssertEqual(notif?.id, "n")
+    }
+
+    func testGetFromLaunchOptionsInvalidPayloadReturnsNil() {
+        let payload: [String: Any] = ["isBlux": false]
+        let opts: [UIApplication.LaunchOptionsKey: Any] = [
+            .remoteNotification: payload
+        ]
+        XCTAssertNil(BluxNotification.getBluxNotificationFromLaunchOptions(launchOptions: opts))
+    }
+
+    // MARK: - toDictionary
+
+    func testToDictionaryProducesAllKeys() {
+        let notif = BluxNotification(
+            id: "n",
+            body: "B",
+            title: "T",
+            url: "U",
+            imageUrl: "I",
+            data: ["k": "v"]
+        )
+        let dict = notif.toDictionary()
+        XCTAssertEqual(dict["id"] as? String, "n")
+        XCTAssertEqual(dict["body"] as? String, "B")
+        XCTAssertEqual(dict["title"] as? String, "T")
+        XCTAssertEqual(dict["url"] as? String, "U")
+        XCTAssertEqual(dict["imageUrl"] as? String, "I")
+        XCTAssertNotNil(dict["data"] as? [String: Any])
+    }
+
+    // MARK: - description
+
+    func testDescriptionContainsId() {
+        let notif = BluxNotification(id: "abc", body: "B", title: nil, url: nil, imageUrl: nil, data: nil)
+        XCTAssertTrue(notif.description.contains("abc"))
+    }
+}

--- a/Tests/BluxClientTests/BluxWebSdkBridgeTests.swift
+++ b/Tests/BluxClientTests/BluxWebSdkBridgeTests.swift
@@ -1,0 +1,372 @@
+import XCTest
+@testable import BluxClient
+
+/// Web SDK(`@blux.ai/sdk-web`)의 `IosBridge`가 보내는 메시지를 iOS SDK가 정확히 처리하는지 검증.
+///
+/// Web SDK가 보내는 형태(IosBridge.postMessage):
+/// ```js
+/// window.webkit.messageHandlers.Blux.postMessage(JSON.stringify({ action, payload }))
+/// ```
+///
+/// 따라서 message.body는 String JSON. 일부 수동 환경에서는 dictionary가 직접 들어올 수 있으니 둘 다 지원.
+///
+/// `WKWebView` 인스턴스 자체를 다루는 attach/detach는 시뮬레이터 GPU 프로세스 초기화를
+/// 강제 트리거해 후속 테스트의 `DispatchQueue.global()` 스케줄링을 stall시킨다 (CI에서 12s+).
+/// attach/detach는 Apple `WKUserContentController` API를 1줄로 감싼 wrapper일 뿐이라
+/// 단위 테스트 가치 대비 비용이 너무 커 제외하고, 본질인 메시지 파싱/dispatch만 검증한다.
+final class BluxWebSdkBridgeTests: XCTestCase {
+    private var guardian: SdkStateGuard!
+    private var bridge: BluxWebSdkBridge!
+
+    override func setUp() {
+        super.setUp()
+        guardian = SdkStateGuard()
+        guardian.clear()
+        bridge = BluxWebSdkBridge()
+    }
+
+    override func tearDown() {
+        guardian.restore()
+        guardian = nil
+        bridge = nil
+        super.tearDown()
+    }
+
+    // MARK: - Static contract
+
+    // Web SDK의 IosBridge.ts가 window.webkit.messageHandlers.Blux로 dispatch.
+    func testHandlerNameMatchesWebSdkExpectation() {
+        XCTAssertEqual(BluxWebSdkBridge.handlerName, "Blux")
+    }
+
+    // MARK: - Message body parsing
+
+    func testHandleStringJSONIsParsed() {
+        let json = "{\"action\":\"signOut\"}"
+        EventHandlers.unhandledNotification = BluxNotification(
+            id: "n", body: "B", title: nil, url: nil, imageUrl: nil, data: nil
+        )
+        bridge.handle(scriptMessageBody: json)
+        XCTAssertNil(EventHandlers.unhandledNotification)
+    }
+
+    func testHandleDictionaryBodyIsParsed() {
+        let dict: [String: Any] = ["action": "signOut"]
+        EventHandlers.unhandledNotification = BluxNotification(
+            id: "n", body: "B", title: nil, url: nil, imageUrl: nil, data: nil
+        )
+        bridge.handle(scriptMessageBody: dict)
+        XCTAssertNil(EventHandlers.unhandledNotification)
+    }
+
+    func testHandleNumberBodyIsIgnored() {
+        EventHandlers.unhandledNotification = BluxNotification(
+            id: "n", body: "B", title: nil, url: nil, imageUrl: nil, data: nil
+        )
+        bridge.handle(scriptMessageBody: 42)
+        XCTAssertNotNil(EventHandlers.unhandledNotification)
+    }
+
+    func testHandleArrayBodyIsIgnored() {
+        EventHandlers.unhandledNotification = BluxNotification(
+            id: "n", body: "B", title: nil, url: nil, imageUrl: nil, data: nil
+        )
+        bridge.handle(scriptMessageBody: [1, 2, 3])
+        XCTAssertNotNil(EventHandlers.unhandledNotification)
+    }
+
+    func testHandleMalformedJSONStringIsIgnored() {
+        EventHandlers.unhandledNotification = BluxNotification(
+            id: "n", body: "B", title: nil, url: nil, imageUrl: nil, data: nil
+        )
+        bridge.handle(scriptMessageBody: "{not valid json")
+        XCTAssertNotNil(EventHandlers.unhandledNotification)
+    }
+
+    func testHandleJSONStringWithNonObjectRootIsIgnored() {
+        EventHandlers.unhandledNotification = BluxNotification(
+            id: "n", body: "B", title: nil, url: nil, imageUrl: nil, data: nil
+        )
+        bridge.handle(scriptMessageBody: "[\"action\",\"signOut\"]")
+        XCTAssertNotNil(EventHandlers.unhandledNotification)
+    }
+
+    func testMissingActionIsIgnored() {
+        EventHandlers.unhandledNotification = BluxNotification(
+            id: "n", body: "B", title: nil, url: nil, imageUrl: nil, data: nil
+        )
+        bridge.handle(scriptMessageBody: "{\"payload\":{}}")
+        XCTAssertNotNil(EventHandlers.unhandledNotification)
+    }
+
+    func testEmptyActionIsIgnored() {
+        EventHandlers.unhandledNotification = BluxNotification(
+            id: "n", body: "B", title: nil, url: nil, imageUrl: nil, data: nil
+        )
+        bridge.handle(scriptMessageBody: "{\"action\":\"\"}")
+        XCTAssertNotNil(EventHandlers.unhandledNotification)
+    }
+
+    func testNonStringActionIsIgnored() {
+        EventHandlers.unhandledNotification = BluxNotification(
+            id: "n", body: "B", title: nil, url: nil, imageUrl: nil, data: nil
+        )
+        bridge.handle(scriptMessageBody: "{\"action\":123}")
+        XCTAssertNotNil(EventHandlers.unhandledNotification)
+    }
+
+    func testUnknownActionIsIgnored() {
+        EventHandlers.unhandledNotification = BluxNotification(
+            id: "n", body: "B", title: nil, url: nil, imageUrl: nil, data: nil
+        )
+        bridge.handle(scriptMessageBody: "{\"action\":\"unknown\"}")
+        XCTAssertNotNil(EventHandlers.unhandledNotification)
+    }
+
+    // MARK: - initialize
+    //
+    // valid credentials는 BluxClient.initialize → DeviceService → URLSession.shared로 실제
+    // HTTP 호출이 발생해 (default Stage가 prod) CI 환경에서 prod endpoint에 도달할 수 있다.
+    // 따라서 valid initialize 변종은 두지 않고, invalid payload의 noop 분기만 검증한다.
+
+    func testInitializeMissingApplicationIdIsNoop() {
+        bridge.handle(scriptMessageBody: "{\"action\":\"initialize\",\"payload\":{\"bluxAPIKey\":\"k\"}}")
+        XCTAssertNil(SdkConfig.apiKeyInUserDefaults)
+        XCTAssertNil(SdkConfig.clientIdInUserDefaults)
+    }
+
+    func testInitializeMissingApiKeyIsNoop() {
+        bridge.handle(scriptMessageBody: "{\"action\":\"initialize\",\"payload\":{\"bluxApplicationId\":\"a\"}}")
+        XCTAssertNil(SdkConfig.apiKeyInUserDefaults)
+        XCTAssertNil(SdkConfig.clientIdInUserDefaults)
+    }
+
+    func testInitializeEmptyApplicationIdIsNoop() {
+        bridge.handle(scriptMessageBody:
+            "{\"action\":\"initialize\",\"payload\":{\"bluxApplicationId\":\"\",\"bluxAPIKey\":\"k\"}}")
+        XCTAssertNil(SdkConfig.apiKeyInUserDefaults)
+    }
+
+    func testInitializeEmptyApiKeyIsNoop() {
+        bridge.handle(scriptMessageBody:
+            "{\"action\":\"initialize\",\"payload\":{\"bluxApplicationId\":\"a\",\"bluxAPIKey\":\"\"}}")
+        XCTAssertNil(SdkConfig.apiKeyInUserDefaults)
+    }
+
+    func testInitializeMissingPayloadIsNoop() {
+        bridge.handle(scriptMessageBody: "{\"action\":\"initialize\"}")
+        XCTAssertNil(SdkConfig.apiKeyInUserDefaults)
+    }
+
+    // MARK: - signIn
+
+    func testSignInWithUserIdInvokesSDKWithoutCrash() {
+        bridge.handle(scriptMessageBody: "{\"action\":\"signIn\",\"payload\":{\"userId\":\"u-1\"}}")
+    }
+
+    func testSignInMissingUserIdIsNoop() {
+        bridge.handle(scriptMessageBody: "{\"action\":\"signIn\",\"payload\":{}}")
+    }
+
+    func testSignInEmptyUserIdIsNoop() {
+        bridge.handle(scriptMessageBody: "{\"action\":\"signIn\",\"payload\":{\"userId\":\"\"}}")
+    }
+
+    func testSignInMissingPayloadIsNoop() {
+        bridge.handle(scriptMessageBody: "{\"action\":\"signIn\"}")
+    }
+
+    // MARK: - signOut
+
+    func testSignOutClearsUnhandledNotification() {
+        EventHandlers.unhandledNotification = BluxNotification(
+            id: "n", body: "B", title: nil, url: nil, imageUrl: nil, data: nil
+        )
+        bridge.handle(scriptMessageBody: "{\"action\":\"signOut\"}")
+        XCTAssertNil(EventHandlers.unhandledNotification)
+    }
+
+    func testSignOutDoesNotRequireIDs() {
+        bridge.handle(scriptMessageBody: "{\"action\":\"signOut\"}")
+    }
+
+    // MARK: - setUserProperties (snake_case)
+
+    func testSetUserPropertiesAcceptsSnakeCaseSchema() {
+        // Web SDK가 보내는 정확한 형태 (UserProperties Codable의 snake_case 키)
+        let body: [String: Any] = [
+            "action": "setUserProperties",
+            "payload": [
+                "phone_number": "010",
+                "email_address": "x@y",
+                "marketing_notification_consent": true,
+                "marketing_notification_sms_consent": false,
+                "age": 25,
+                "gender": "female"
+            ]
+        ]
+        bridge.handle(scriptMessageBody: body)
+        // 사이드이펙트 직접 검증 어려움. 디코딩 자체가 throw 안 하면 통과 (BluxClient는 IDs 없으니 early return)
+    }
+
+    func testSetUserPropertiesNonDictionaryIsNoop() {
+        bridge.handle(scriptMessageBody: "{\"action\":\"setUserProperties\",\"payload\":\"not-a-dict\"}")
+    }
+
+    func testSetUserPropertiesMissingPayloadIsNoop() {
+        bridge.handle(scriptMessageBody: "{\"action\":\"setUserProperties\"}")
+    }
+
+    func testSetUserPropertiesInvalidSchemaIsNoop() {
+        // age는 Int여야 함. String이면 디코딩 실패하지만 bridge는 swallow
+        let body: [String: Any] = [
+            "action": "setUserProperties",
+            "payload": ["age": "not-a-number"]
+        ]
+        bridge.handle(scriptMessageBody: body)
+    }
+
+    // MARK: - setCustomUserProperties
+
+    func testSetCustomUserPropertiesAcceptsArbitraryKeys() {
+        let body: [String: Any] = [
+            "action": "setCustomUserProperties",
+            "payload": [
+                "favorite_color": "blue",
+                "loyalty_points": 100,
+                "tags": ["a", "b"]
+            ]
+        ]
+        bridge.handle(scriptMessageBody: body)
+    }
+
+    func testSetCustomUserPropertiesSanitizesNSNullToNil() {
+        // Web SDK에서 null로 보낸 값이 NSNull로 변환되는데 bridge가 nil로 처리해야 함
+        let body: [String: Any] = [
+            "action": "setCustomUserProperties",
+            "payload": ["removed_key": NSNull()]
+        ]
+        bridge.handle(scriptMessageBody: body)
+    }
+
+    func testSetCustomUserPropertiesNonDictionaryIsNoop() {
+        bridge.handle(scriptMessageBody: "{\"action\":\"setCustomUserProperties\",\"payload\":42}")
+    }
+
+    func testSetCustomUserPropertiesMissingPayloadIsNoop() {
+        bridge.handle(scriptMessageBody: "{\"action\":\"setCustomUserProperties\"}")
+    }
+
+    // MARK: - sendEvent (Web SDK EventRequest 호환)
+
+    func testSendEventBuildsEventFromSnakeCasePayload() {
+        // Web SDK의 EventRequest: { id, event_type, captured_at, event_properties?, custom_event_properties?, internal_event_properties? }
+        let body: [String: Any] = [
+            "action": "sendEvent",
+            "payload": [
+                "requests": [
+                    [
+                        "id": "req-1",  // Web SDK uuid - iOS는 무시
+                        "event_type": "page_view",
+                        "captured_at": "2025-01-01T00:00:00.000Z",
+                        "event_properties": ["page": "home"],
+                        "custom_event_properties": ["scroll": 0.5],
+                        "internal_event_properties": ["url": "/home", "ref": "/index"]
+                    ]
+                ]
+            ]
+        ]
+        // BluxClient.sendRequestData를 통해 EventService.sendEvent로 전달.
+        // SdkConfig IDs가 없어 EventQueue 안에서 early return.
+        // 크래시만 안 나면 통과.
+        bridge.handle(scriptMessageBody: body)
+    }
+
+    func testSendEventRequestsMissingIsNoop() {
+        bridge.handle(scriptMessageBody: "{\"action\":\"sendEvent\",\"payload\":{}}")
+    }
+
+    func testSendEventRequestsEmptyArrayIsNoop() {
+        bridge.handle(scriptMessageBody: "{\"action\":\"sendEvent\",\"payload\":{\"requests\":[]}}")
+    }
+
+    func testSendEventNonDictionaryPayloadIsNoop() {
+        bridge.handle(scriptMessageBody: "{\"action\":\"sendEvent\",\"payload\":\"x\"}")
+    }
+
+    func testSendEventSkipsRequestsWithoutEventType() {
+        let body: [String: Any] = [
+            "action": "sendEvent",
+            "payload": [
+                "requests": [
+                    ["captured_at": "2025-01-01T00:00:00.000Z"], // event_type 누락 → 스킵
+                    ["event_type": "valid"] // 정상
+                ]
+            ]
+        ]
+        bridge.handle(scriptMessageBody: body)
+    }
+
+    func testSendEventSkipsRequestsWithEmptyEventType() {
+        let body: [String: Any] = [
+            "action": "sendEvent",
+            "payload": [
+                "requests": [["event_type": ""]]
+            ]
+        ]
+        bridge.handle(scriptMessageBody: body)
+    }
+
+    // MARK: - Web SDK full contract simulation
+
+    /// IosBridge.postMessage가 실제로 만드는 JSON 형태를 그대로 재현.
+    /// Web SDK의 IosBridge.ts:
+    ///   handler.postMessage(JSON.stringify({ action, payload }))
+    /// initialize 변종은 prod HTTP 호출 위험으로 제외 (위 MARK: - initialize 주석 참고).
+
+    func testFullSignOutContractFromWebSdk() throws {
+        // Web SDK IosBridge.signOut(): postMessage("signOut") - payload 없음
+        let envelope: [String: Any] = ["action": "signOut"]
+        let data = try JSONSerialization.data(withJSONObject: envelope)
+        let json = String(data: data, encoding: .utf8)!
+
+        EventHandlers.unhandledNotification = BluxNotification(
+            id: "x", body: "x", title: nil, url: nil, imageUrl: nil, data: nil
+        )
+        bridge.handle(scriptMessageBody: json)
+        XCTAssertNil(EventHandlers.unhandledNotification)
+    }
+
+    func testFullSendEventContractFromWebSdk() throws {
+        // Web SDK에서 AddOrderEvent를 보낸 시나리오를 정확히 재현
+        let request: [String: Any] = [
+            "id": UUID().uuidString,
+            "event_type": "order",
+            "event_properties": [
+                "order_id": "ORD-1",
+                "paid_amount": 90.0,
+                "order_amount": 100.0,
+                "items": [
+                    ["id": "p1", "price": 50.0, "quantity": 2]
+                ]
+            ],
+            "custom_event_properties": [
+                "coupon_code": "SAVE10"
+            ],
+            "internal_event_properties": [
+                "url": "https://example.com/checkout",
+                "ref": "https://example.com/cart"
+            ],
+            "captured_at": "2025-01-01T12:00:00.000Z"
+        ]
+        let envelope: [String: Any] = [
+            "action": "sendEvent",
+            "payload": ["requests": [request]]
+        ]
+        let data = try JSONSerialization.data(withJSONObject: envelope)
+        let json = String(data: data, encoding: .utf8)!
+        bridge.handle(scriptMessageBody: json)
+        // 디코딩까지 정상이면 EventService.sendEvent까지 호출됨.
+        // SdkConfig IDs 없어 EventQueue가 early return하지만 크래시 없으면 통과.
+    }
+}

--- a/Tests/BluxClientTests/ColdStartNotificationManagerTests.swift
+++ b/Tests/BluxClientTests/ColdStartNotificationManagerTests.swift
@@ -1,0 +1,79 @@
+import XCTest
+import UIKit
+@testable import BluxClient
+
+final class ColdStartNotificationManagerTests: XCTestCase {
+    override func setUp() {
+        super.setUp()
+        ColdStartNotificationManager.coldStartNotification = nil
+        ColdStartNotificationManager.reset()
+    }
+
+    override func tearDown() {
+        ColdStartNotificationManager.coldStartNotification = nil
+        ColdStartNotificationManager.reset()
+        super.tearDown()
+    }
+
+    // MARK: - trackOpen dedup
+
+    func testTrackOpenDedupsByNotificationId() {
+        let n = BluxNotification(id: "uniq-csm-1", body: "B", title: nil, url: nil, imageUrl: nil, data: nil)
+
+        ColdStartNotificationManager.trackOpen(n)
+        XCTAssertEqual(ColdStartNotificationManager.lastOpenedNotificationId, "uniq-csm-1")
+
+        ColdStartNotificationManager.trackOpen(n)
+        XCTAssertEqual(ColdStartNotificationManager.lastOpenedNotificationId, "uniq-csm-1")
+    }
+
+    func testTrackOpenAcceptsNewIdsAfterFirst() {
+        let n1 = BluxNotification(id: "uniq-csm-2-a", body: "B", title: nil, url: nil, imageUrl: nil, data: nil)
+        let n2 = BluxNotification(id: "uniq-csm-2-b", body: "B", title: nil, url: nil, imageUrl: nil, data: nil)
+
+        ColdStartNotificationManager.trackOpen(n1)
+        ColdStartNotificationManager.trackOpen(n2)
+        XCTAssertEqual(ColdStartNotificationManager.lastOpenedNotificationId, "uniq-csm-2-b")
+    }
+
+    // reset()은 hasProcessedLaunchOptions/coldStartNotification만 비우고
+    // lastOpenedNotificationId는 유지해야 한다 (didReceive가 먼저 set한 dedup 키 보존).
+    func testResetPreservesLastOpenedNotificationId() {
+        let n = BluxNotification(id: "uniq-csm-3", body: "B", title: nil, url: nil, imageUrl: nil, data: nil)
+        ColdStartNotificationManager.trackOpen(n)
+        XCTAssertEqual(ColdStartNotificationManager.lastOpenedNotificationId, "uniq-csm-3")
+
+        ColdStartNotificationManager.reset()
+        XCTAssertEqual(ColdStartNotificationManager.lastOpenedNotificationId, "uniq-csm-3")
+    }
+
+    // MARK: - hasProcessedLaunchOptions guard
+
+    // 같은 launchOptions가 페이지 전환마다 재전달되는 하이브리드 환경에서 process() 후
+    // 재진입을 차단해야 한다. reset() 후엔 다시 받아들임.
+    func testProcessBlocksSubsequentSetColdStartNotification() {
+        let payload: [String: Any] = [
+            "isBlux": true,
+            "notificationId": "uniq-csm-4",
+            "aps": ["alert": ["body": "B"]]
+        ]
+        let opts: [UIApplication.LaunchOptionsKey: Any] = [.remoteNotification: payload]
+
+        ColdStartNotificationManager.setColdStartNotification(launchOptions: opts)
+        XCTAssertNotNil(ColdStartNotificationManager.coldStartNotification)
+
+        ColdStartNotificationManager.process()
+
+        ColdStartNotificationManager.setColdStartNotification(launchOptions: opts)
+        XCTAssertNil(ColdStartNotificationManager.coldStartNotification)
+
+        ColdStartNotificationManager.reset()
+        ColdStartNotificationManager.setColdStartNotification(launchOptions: opts)
+        XCTAssertNotNil(ColdStartNotificationManager.coldStartNotification)
+    }
+
+    func testProcessIsNoopWhenNoColdStartNotification() {
+        ColdStartNotificationManager.process()
+        XCTAssertNil(ColdStartNotificationManager.coldStartNotification)
+    }
+}

--- a/Tests/BluxClientTests/CollectEventsResponseTests.swift
+++ b/Tests/BluxClientTests/CollectEventsResponseTests.swift
@@ -1,0 +1,78 @@
+import XCTest
+@testable import BluxClient
+
+final class CollectEventsResponseTests: XCTestCase {
+    private let decoder = JSONDecoder()
+
+    func testDecodeMinimalResponse() throws {
+        let json = "{}".data(using: .utf8)!
+        let response = try decoder.decode(CollectEventsResponse.self, from: json)
+        XCTAssertNil(response.nextPollDelayMs)
+        XCTAssertNil(response.inapp)
+    }
+
+    func testDecodeNextPollDelayOnly() throws {
+        let json = "{\"nextPollDelayMs\":3000}".data(using: .utf8)!
+        let response = try decoder.decode(CollectEventsResponse.self, from: json)
+        XCTAssertEqual(response.nextPollDelayMs, 3000)
+        XCTAssertNil(response.inapp)
+    }
+
+    func testDecodeInappOnly() throws {
+        let json = """
+        {
+          "inapp": {
+            "notificationId": "n1",
+            "htmlString": "<html></html>",
+            "inappId": "i1",
+            "baseUrl": "https://cdn.blux.ai"
+          }
+        }
+        """.data(using: .utf8)!
+        let response = try decoder.decode(CollectEventsResponse.self, from: json)
+        XCTAssertNil(response.nextPollDelayMs)
+        XCTAssertNotNil(response.inapp)
+        XCTAssertEqual(response.inapp?.notificationId, "n1")
+        XCTAssertEqual(response.inapp?.htmlString, "<html></html>")
+        XCTAssertEqual(response.inapp?.inappId, "i1")
+        XCTAssertEqual(response.inapp?.baseUrl, "https://cdn.blux.ai")
+    }
+
+    func testDecodeFullResponse() throws {
+        let json = """
+        {
+          "nextPollDelayMs": 5000,
+          "inapp": {
+            "notificationId": "n",
+            "htmlString": "h",
+            "inappId": "i",
+            "baseUrl": "b"
+          }
+        }
+        """.data(using: .utf8)!
+        let response = try decoder.decode(CollectEventsResponse.self, from: json)
+        XCTAssertEqual(response.nextPollDelayMs, 5000)
+        XCTAssertEqual(response.inapp?.notificationId, "n")
+    }
+
+    func testDecodeMissingInappFieldThrows() {
+        // inapp이 있다면 모든 필드가 필수
+        let json = """
+        { "inapp": { "notificationId": "n" } }
+        """.data(using: .utf8)!
+        XCTAssertThrowsError(try decoder.decode(CollectEventsResponse.self, from: json))
+    }
+
+    func testDecodeNegativeDelayPassesThrough() throws {
+        // 서버가 음수 보내도 디코딩 자체는 통과 (검증은 EventService에서 max(_, 3000) 적용)
+        let json = "{\"nextPollDelayMs\":-1000}".data(using: .utf8)!
+        let response = try decoder.decode(CollectEventsResponse.self, from: json)
+        XCTAssertEqual(response.nextPollDelayMs, -1000)
+    }
+
+    func testDecodeIgnoresExtraFields() throws {
+        let json = "{\"nextPollDelayMs\":1000,\"unknown\":\"value\"}".data(using: .utf8)!
+        let response = try decoder.decode(CollectEventsResponse.self, from: json)
+        XCTAssertEqual(response.nextPollDelayMs, 1000)
+    }
+}

--- a/Tests/BluxClientTests/CollectEventsResponseTests.swift
+++ b/Tests/BluxClientTests/CollectEventsResponseTests.swift
@@ -70,6 +70,13 @@ final class CollectEventsResponseTests: XCTestCase {
         XCTAssertEqual(response.nextPollDelayMs, -1000)
     }
 
+    // 0초가 그대로 통과되어도 EventService 내부에서 max(_, 3000)으로 정규화된다.
+    func testDecodeZeroDelayPassesThrough() throws {
+        let json = "{\"nextPollDelayMs\":0}".data(using: .utf8)!
+        let response = try decoder.decode(CollectEventsResponse.self, from: json)
+        XCTAssertEqual(response.nextPollDelayMs, 0)
+    }
+
     func testDecodeIgnoresExtraFields() throws {
         let json = "{\"nextPollDelayMs\":1000,\"unknown\":\"value\"}".data(using: .utf8)!
         let response = try decoder.decode(CollectEventsResponse.self, from: json)

--- a/Tests/BluxClientTests/CustomEventValueTests.swift
+++ b/Tests/BluxClientTests/CustomEventValueTests.swift
@@ -1,0 +1,184 @@
+import XCTest
+@testable import BluxClient
+
+final class CustomEventValueTests: XCTestCase {
+    private let encoder = JSONEncoder()
+    private let decoder = JSONDecoder()
+
+    // MARK: - Encoding
+
+    func testEncodeString() throws {
+        let data = try encoder.encode(CustomEventValue.string("hello"))
+        XCTAssertEqual(String(data: data, encoding: .utf8), "\"hello\"")
+    }
+
+    func testEncodeBool() throws {
+        let data = try encoder.encode(CustomEventValue.bool(false))
+        XCTAssertEqual(String(data: data, encoding: .utf8), "false")
+    }
+
+    func testEncodeInt() throws {
+        let data = try encoder.encode(CustomEventValue.int(7))
+        XCTAssertEqual(String(data: data, encoding: .utf8), "7")
+    }
+
+    func testEncodeDouble() throws {
+        let data = try encoder.encode(CustomEventValue.double(0.5))
+        XCTAssertEqual(String(data: data, encoding: .utf8), "0.5")
+    }
+
+    func testEncodeStringArray() throws {
+        let data = try encoder.encode(CustomEventValue.stringArray(["x"]))
+        XCTAssertEqual(String(data: data, encoding: .utf8), "[\"x\"]")
+    }
+
+    // MARK: - Decoding ordering: Bool > Int > Double > String > StringArray
+
+    func testDecodeBoolBeforeInt() throws {
+        // 불리언 먼저 시도되므로 true/false는 .bool로
+        let value = try decoder.decode(CustomEventValue.self, from: "true".data(using: .utf8)!)
+        guard case .bool(true) = value else {
+            XCTFail("Expected .bool(true), got \(value)")
+            return
+        }
+    }
+
+    func testDecodeIntegerLiteralAsInt() throws {
+        let value = try decoder.decode(CustomEventValue.self, from: "10".data(using: .utf8)!)
+        guard case .int(10) = value else {
+            XCTFail("Expected .int(10), got \(value)")
+            return
+        }
+    }
+
+    func testDecodeFractionalAsDouble() throws {
+        let value = try decoder.decode(CustomEventValue.self, from: "1.25".data(using: .utf8)!)
+        guard case .double(let d) = value else {
+            XCTFail("Expected .double, got \(value)")
+            return
+        }
+        XCTAssertEqual(d, 1.25, accuracy: 0.0001)
+    }
+
+    func testDecodeString() throws {
+        let value = try decoder.decode(CustomEventValue.self, from: "\"abc\"".data(using: .utf8)!)
+        guard case .string("abc") = value else {
+            XCTFail("Expected .string(\"abc\"), got \(value)")
+            return
+        }
+    }
+
+    func testDecodeStringArray() throws {
+        let value = try decoder.decode(CustomEventValue.self, from: "[\"a\",\"b\"]".data(using: .utf8)!)
+        guard case .stringArray(let arr) = value else {
+            XCTFail("Expected .stringArray, got \(value)")
+            return
+        }
+        XCTAssertEqual(arr, ["a", "b"])
+    }
+
+    func testDecodeUnsupportedThrows() {
+        // 객체는 지원 안 됨 (CustomValue와 다르게 null도 지원 안 함)
+        XCTAssertThrowsError(try decoder.decode(CustomEventValue.self, from: "{}".data(using: .utf8)!))
+    }
+
+    func testDecodeNullThrows() {
+        // CustomEventValue는 null 케이스가 없음
+        XCTAssertThrowsError(try decoder.decode(CustomEventValue.self, from: "null".data(using: .utf8)!))
+    }
+
+    // MARK: - fromAny
+
+    func testFromAnyNilReturnsNil() {
+        XCTAssertNil(CustomEventValue.fromAny(nil))
+    }
+
+    func testFromAnyBool() {
+        guard case .bool(true)? = CustomEventValue.fromAny(true) else {
+            XCTFail("Expected .bool(true)")
+            return
+        }
+    }
+
+    func testFromAnyInt() {
+        guard case .int(42)? = CustomEventValue.fromAny(42) else {
+            XCTFail("Expected .int(42)")
+            return
+        }
+    }
+
+    func testFromAnyDouble() {
+        guard case .double(let d)? = CustomEventValue.fromAny(3.14) else {
+            XCTFail("Expected .double")
+            return
+        }
+        XCTAssertEqual(d, 3.14, accuracy: 0.0001)
+    }
+
+    func testFromAnyString() {
+        guard case .string("hello")? = CustomEventValue.fromAny("hello") else {
+            XCTFail("Expected .string")
+            return
+        }
+    }
+
+    func testFromAnyStringArray() {
+        guard case .stringArray(let arr)? = CustomEventValue.fromAny(["a", "b"]) else {
+            XCTFail("Expected .stringArray")
+            return
+        }
+        XCTAssertEqual(arr, ["a", "b"])
+    }
+
+    func testFromAnyUnsupportedReturnsNil() {
+        XCTAssertNil(CustomEventValue.fromAny([1, 2, 3]))
+        XCTAssertNil(CustomEventValue.fromAny(["key": "value"]))
+        XCTAssertNil(CustomEventValue.fromAny(NSObject()))
+    }
+
+    // MARK: - dictionaryFromAny
+
+    func testDictionaryFromAnyConvertsKnownTypes() {
+        let input: [String: Any] = [
+            "name": "Alice",
+            "age": 30,
+            "score": 99.5,
+            "active": true,
+            "tags": ["a", "b"]
+        ]
+        let result = CustomEventValue.dictionaryFromAny(input)
+
+        XCTAssertEqual(result.count, 5)
+        if case .string("Alice")? = result["name"] {} else { XCTFail("name wrong") }
+        if case .int(30)? = result["age"] {} else { XCTFail("age wrong") }
+        if case .double(let s)? = result["score"] {
+            XCTAssertEqual(s, 99.5, accuracy: 0.0001)
+        } else {
+            XCTFail("score wrong")
+        }
+        if case .bool(true)? = result["active"] {} else { XCTFail("active wrong") }
+        if case .stringArray(let t)? = result["tags"] {
+            XCTAssertEqual(t, ["a", "b"])
+        } else {
+            XCTFail("tags wrong")
+        }
+    }
+
+    func testDictionaryFromAnyDropsUnsupportedTypes() {
+        let input: [String: Any] = [
+            "good": "value",
+            "bad": NSObject(),
+            "alsoBad": [1, 2]
+        ]
+        let result = CustomEventValue.dictionaryFromAny(input)
+
+        XCTAssertEqual(result.count, 1)
+        XCTAssertNotNil(result["good"])
+        XCTAssertNil(result["bad"])
+        XCTAssertNil(result["alsoBad"])
+    }
+
+    func testDictionaryFromAnyEmptyInputReturnsEmpty() {
+        XCTAssertTrue(CustomEventValue.dictionaryFromAny([:]).isEmpty)
+    }
+}

--- a/Tests/BluxClientTests/CustomEventValueTests.swift
+++ b/Tests/BluxClientTests/CustomEventValueTests.swift
@@ -130,6 +130,27 @@ final class CustomEventValueTests: XCTestCase {
         XCTAssertEqual(arr, ["a", "b"])
     }
 
+    // NSNumber로 들어오는 true가 .int(1)로 분류되면 서버에 boolean이 0/1로 전달됨.
+    func testFromAnyBoolNSNumberStaysBool() {
+        guard case .bool(true)? = CustomEventValue.fromAny(NSNumber(value: true)) else {
+            XCTFail("NSNumber(true) must convert to .bool(true)")
+            return
+        }
+    }
+
+    func testFromAnyTrueLiteralIsBool() {
+        guard case .bool(true)? = CustomEventValue.fromAny(true) else {
+            XCTFail("true literal must convert to .bool(true)")
+            return
+        }
+    }
+
+    func testFromAnyIntLiteralStaysInt() {
+        if case .bool = CustomEventValue.fromAny(1) {
+            XCTFail("1 (Int literal) must NOT convert to .bool")
+        }
+    }
+
     func testFromAnyUnsupportedReturnsNil() {
         XCTAssertNil(CustomEventValue.fromAny([1, 2, 3]))
         XCTAssertNil(CustomEventValue.fromAny(["key": "value"]))

--- a/Tests/BluxClientTests/CustomValueTests.swift
+++ b/Tests/BluxClientTests/CustomValueTests.swift
@@ -118,6 +118,19 @@ final class CustomValueTests: XCTestCase {
 
     // MARK: - Round-trip
 
+    // Bool은 Int보다 먼저 디코딩되어야 한다.
+    // (NSNumber로 들어오는 true/false가 .int(1)/.int(0)로 분류되면 서버에 boolean이 0/1로 전달됨)
+    func testDecodeBoolIsNotMisclassifiedAsInt() throws {
+        let value = try decoder.decode(CustomValue.self, from: "false".data(using: .utf8)!)
+        if case .int = value {
+            XCTFail("Bool false must NOT decode as .int")
+        }
+        guard case .bool(false) = value else {
+            XCTFail("Expected .bool(false), got \(value)")
+            return
+        }
+    }
+
     func testRoundTripAllVariants() throws {
         let cases: [CustomValue] = [
             .string("test"),

--- a/Tests/BluxClientTests/CustomValueTests.swift
+++ b/Tests/BluxClientTests/CustomValueTests.swift
@@ -1,0 +1,138 @@
+import XCTest
+@testable import BluxClient
+
+final class CustomValueTests: XCTestCase {
+    private let encoder = JSONEncoder()
+    private let decoder = JSONDecoder()
+
+    // MARK: - Encoding
+
+    func testEncodeString() throws {
+        let value = CustomValue.string("hello")
+        let data = try encoder.encode(value)
+        XCTAssertEqual(String(data: data, encoding: .utf8), "\"hello\"")
+    }
+
+    func testEncodeBoolTrue() throws {
+        let data = try encoder.encode(CustomValue.bool(true))
+        XCTAssertEqual(String(data: data, encoding: .utf8), "true")
+    }
+
+    func testEncodeBoolFalse() throws {
+        let data = try encoder.encode(CustomValue.bool(false))
+        XCTAssertEqual(String(data: data, encoding: .utf8), "false")
+    }
+
+    func testEncodeInt() throws {
+        let data = try encoder.encode(CustomValue.int(42))
+        XCTAssertEqual(String(data: data, encoding: .utf8), "42")
+    }
+
+    func testEncodeNegativeInt() throws {
+        let data = try encoder.encode(CustomValue.int(-7))
+        XCTAssertEqual(String(data: data, encoding: .utf8), "-7")
+    }
+
+    func testEncodeDouble() throws {
+        let data = try encoder.encode(CustomValue.double(3.5))
+        XCTAssertEqual(String(data: data, encoding: .utf8), "3.5")
+    }
+
+    func testEncodeNull() throws {
+        let data = try encoder.encode(CustomValue.null)
+        XCTAssertEqual(String(data: data, encoding: .utf8), "null")
+    }
+
+    func testEncodeStringArray() throws {
+        let data = try encoder.encode(CustomValue.stringArray(["a", "b"]))
+        XCTAssertEqual(String(data: data, encoding: .utf8), "[\"a\",\"b\"]")
+    }
+
+    func testEncodeEmptyStringArray() throws {
+        let data = try encoder.encode(CustomValue.stringArray([]))
+        XCTAssertEqual(String(data: data, encoding: .utf8), "[]")
+    }
+
+    // MARK: - Decoding
+
+    func testDecodeString() throws {
+        let value = try decoder.decode(CustomValue.self, from: "\"hello\"".data(using: .utf8)!)
+        guard case .string("hello") = value else {
+            XCTFail("Expected .string(\"hello\"), got \(value)")
+            return
+        }
+    }
+
+    func testDecodeBool() throws {
+        let value = try decoder.decode(CustomValue.self, from: "true".data(using: .utf8)!)
+        guard case .bool(true) = value else {
+            XCTFail("Expected .bool(true), got \(value)")
+            return
+        }
+    }
+
+    func testDecodeInt() throws {
+        let value = try decoder.decode(CustomValue.self, from: "42".data(using: .utf8)!)
+        guard case .int(42) = value else {
+            XCTFail("Expected .int(42), got \(value)")
+            return
+        }
+    }
+
+    func testDecodeDouble() throws {
+        // 정수형이 먼저 매칭되니, 명확히 double인 케이스
+        let value = try decoder.decode(CustomValue.self, from: "1.5".data(using: .utf8)!)
+        guard case .double(let d) = value else {
+            XCTFail("Expected .double, got \(value)")
+            return
+        }
+        XCTAssertEqual(d, 1.5, accuracy: 0.0001)
+    }
+
+    func testDecodeStringArray() throws {
+        let value = try decoder.decode(CustomValue.self, from: "[\"a\",\"b\"]".data(using: .utf8)!)
+        guard case .stringArray(let arr) = value else {
+            XCTFail("Expected .stringArray, got \(value)")
+            return
+        }
+        XCTAssertEqual(arr, ["a", "b"])
+    }
+
+    func testDecodeNull() throws {
+        let value = try decoder.decode(CustomValue.self, from: "null".data(using: .utf8)!)
+        guard case .null = value else {
+            XCTFail("Expected .null, got \(value)")
+            return
+        }
+    }
+
+    func testDecodeUnsupportedTypeThrows() {
+        // 객체 형태는 지원되지 않음
+        XCTAssertThrowsError(try decoder.decode(CustomValue.self, from: "{}".data(using: .utf8)!))
+    }
+
+    func testDecodeMixedNumberArrayThrows() {
+        // 숫자 배열은 stringArray가 아니라서 fail
+        XCTAssertThrowsError(try decoder.decode(CustomValue.self, from: "[1,2,3]".data(using: .utf8)!))
+    }
+
+    // MARK: - Round-trip
+
+    func testRoundTripAllVariants() throws {
+        let cases: [CustomValue] = [
+            .string("test"),
+            .bool(true),
+            .int(123),
+            .double(2.71),
+            .null,
+            .stringArray(["x", "y", "z"])
+        ]
+        for original in cases {
+            let data = try encoder.encode(original)
+            let decoded = try decoder.decode(CustomValue.self, from: data)
+            // Compare by re-encoding (Equatable 미정의)
+            let reData = try encoder.encode(decoded)
+            XCTAssertEqual(data, reData, "Round-trip mismatch for \(original)")
+        }
+    }
+}

--- a/Tests/BluxClientTests/DeviceServiceTests.swift
+++ b/Tests/BluxClientTests/DeviceServiceTests.swift
@@ -1,0 +1,93 @@
+import XCTest
+@testable import BluxClient
+
+final class DeviceServiceTests: XCTestCase {
+    private var guardian: SdkStateGuard!
+
+    override func setUp() {
+        super.setUp()
+        guardian = SdkStateGuard()
+        guardian.clear()
+    }
+
+    override func tearDown() {
+        guardian.restore()
+        guardian = nil
+        super.tearDown()
+    }
+
+    // MARK: - getBluxDeviceInfo
+
+    func testGetBluxDeviceInfoFillsRequiredFields() {
+        let info = DeviceService.getBluxDeviceInfo()
+        XCTAssertEqual(info.platform, "ios")
+        XCTAssertFalse(info.deviceModel.isEmpty)
+        XCTAssertFalse(info.osVersion.isEmpty)
+        XCTAssertEqual(info.sdkVersion, SdkConfig.sdkVersion)
+        XCTAssertEqual(info.sdkType, SdkConfig.sdkType.rawValue)
+        XCTAssertFalse(info.timezone.isEmpty)
+    }
+
+    func testGetBluxDeviceInfoInheritsSessionId() {
+        SdkConfig.sessionId = "session-X"
+        let info = DeviceService.getBluxDeviceInfo()
+        XCTAssertEqual(info.sessionId, "session-X")
+    }
+
+    func testGetBluxDeviceInfoInheritsBluxIds() {
+        SdkConfig.bluxIdInUserDefaults = "B"
+        SdkConfig.deviceIdInUserDefaults = "D"
+        SdkConfig.userIdInUserDefaults = "U"
+
+        let info = DeviceService.getBluxDeviceInfo()
+        XCTAssertEqual(info.bluxId, "B")
+        XCTAssertEqual(info.deviceId, "D")
+        XCTAssertEqual(info.userId, "U")
+    }
+
+    func testGetBluxDeviceInfoLanguageCodeFromPreferredLocale() {
+        let info = DeviceService.getBluxDeviceInfo()
+        // languageCode는 nullable이지만 시뮬레이터 환경이면 일반적으로 비어있지 않음.
+        // 시스템 차이로 nil일 수도 있어 단순히 크래시 안 나면 통과.
+        _ = info.languageCode
+    }
+
+    // MARK: - initializeDevice 사전조건
+
+    func testInitializeDeviceFailsWhenNoClientId() {
+        let exp = expectation(description: "initializeDevice fails fast")
+        var capturedResult: Result<BluxDeviceResponse, Error>?
+
+        DeviceService.initializeDevice(deviceId: nil) { result in
+            capturedResult = result
+            exp.fulfill()
+        }
+
+        wait(for: [exp], timeout: 2.0)
+        guard case .failure(let error) = capturedResult else {
+            XCTFail("Expected failure when clientId is nil")
+            return
+        }
+        let nsError = error as NSError
+        XCTAssertEqual(nsError.domain, "DeviceService")
+    }
+
+    // MARK: - updatePushToken 사전조건
+
+    func testUpdatePushTokenFailsWhenNoIds() {
+        struct DummyBody: Codable { let push_token: String? }
+        let exp = expectation(description: "updatePushToken fails fast")
+        var capturedResult: Result<BluxDeviceResponse, Error>?
+
+        DeviceService.updatePushToken(body: DummyBody(push_token: nil)) { result in
+            capturedResult = result
+            exp.fulfill()
+        }
+
+        wait(for: [exp], timeout: 2.0)
+        guard case .failure = capturedResult else {
+            XCTFail("Expected failure when IDs are missing")
+            return
+        }
+    }
+}

--- a/Tests/BluxClientTests/EventHandlersTests.swift
+++ b/Tests/BluxClientTests/EventHandlersTests.swift
@@ -1,0 +1,113 @@
+import XCTest
+@testable import BluxClient
+
+/// EventHandlers는 enum 기반 정적 슬롯이라 테스트 간 격리에 주의.
+/// 매 테스트 setUp/tearDown에서 모든 슬롯을 비운다.
+final class EventHandlersTests: XCTestCase {
+    override func setUp() {
+        super.setUp()
+        clearAll()
+    }
+
+    override func tearDown() {
+        clearAll()
+        super.tearDown()
+    }
+
+    private func clearAll() {
+        EventHandlers.unhandledNotification = nil
+        EventHandlers.notificationForegroundWillDisplay = nil
+        EventHandlers.notificationClicked = nil
+        EventHandlers.inAppCustomActionHandlers = []
+    }
+
+    // MARK: - 단일 핸들러 슬롯
+
+    func testUnhandledNotificationSlotStartsNil() {
+        XCTAssertNil(EventHandlers.unhandledNotification)
+    }
+
+    func testUnhandledNotificationStoresAndRetrieves() {
+        let n = BluxNotification(id: "n", body: "B", title: nil, url: nil, imageUrl: nil, data: nil)
+        EventHandlers.unhandledNotification = n
+        XCTAssertNotNil(EventHandlers.unhandledNotification)
+        XCTAssertEqual(EventHandlers.unhandledNotification?.id, "n")
+    }
+
+    func testNotificationClickedSlotStoresClosure() {
+        var captured: BluxNotification?
+        EventHandlers.notificationClicked = { n in captured = n }
+
+        let n = BluxNotification(id: "x", body: "B", title: nil, url: nil, imageUrl: nil, data: nil)
+        EventHandlers.notificationClicked?(n)
+        XCTAssertEqual(captured?.id, "x")
+    }
+
+    // MARK: - inAppCustomActionHandlers
+
+    func testInAppHandlerListStartsEmpty() {
+        XCTAssertTrue(EventHandlers.inAppCustomActionHandlers.isEmpty)
+    }
+
+    func testAddInAppCustomActionHandlerRegistersOne() {
+        var calledWith: (String, [String: Any])?
+        let unsubscribe = BluxClient.addInAppCustomActionHandler { actionId, data in
+            calledWith = (actionId, data)
+        }
+
+        XCTAssertEqual(EventHandlers.inAppCustomActionHandlers.count, 1)
+
+        // 등록된 handler 직접 invoke
+        EventHandlers.inAppCustomActionHandlers[0].handler("share", ["url": "https://x"])
+        XCTAssertEqual(calledWith?.0, "share")
+        XCTAssertEqual(calledWith?.1["url"] as? String, "https://x")
+
+        // unsubscribe
+        unsubscribe()
+        XCTAssertTrue(EventHandlers.inAppCustomActionHandlers.isEmpty)
+    }
+
+    func testAddInAppCustomActionHandlerRegistersMultiple() {
+        let u1 = BluxClient.addInAppCustomActionHandler { _, _ in }
+        let u2 = BluxClient.addInAppCustomActionHandler { _, _ in }
+        let u3 = BluxClient.addInAppCustomActionHandler { _, _ in }
+
+        XCTAssertEqual(EventHandlers.inAppCustomActionHandlers.count, 3)
+
+        u2()
+        XCTAssertEqual(EventHandlers.inAppCustomActionHandlers.count, 2)
+
+        u1()
+        u3()
+        XCTAssertTrue(EventHandlers.inAppCustomActionHandlers.isEmpty)
+    }
+
+    func testAddInAppCustomActionHandlerEachHasUniqueId() {
+        _ = BluxClient.addInAppCustomActionHandler { _, _ in }
+        _ = BluxClient.addInAppCustomActionHandler { _, _ in }
+
+        let ids = EventHandlers.inAppCustomActionHandlers.map { $0.id }
+        XCTAssertEqual(Set(ids).count, ids.count, "Each handler must have a unique id")
+    }
+
+    func testUnsubscribeIsIdempotent() {
+        let unsubscribe = BluxClient.addInAppCustomActionHandler { _, _ in }
+        XCTAssertEqual(EventHandlers.inAppCustomActionHandlers.count, 1)
+        unsubscribe()
+        XCTAssertEqual(EventHandlers.inAppCustomActionHandlers.count, 0)
+        unsubscribe() // 두 번째 호출도 안전
+        XCTAssertEqual(EventHandlers.inAppCustomActionHandlers.count, 0)
+    }
+
+    func testHandlersExecuteInRegistrationOrder() {
+        var sequence: [Int] = []
+        _ = BluxClient.addInAppCustomActionHandler { _, _ in sequence.append(1) }
+        _ = BluxClient.addInAppCustomActionHandler { _, _ in sequence.append(2) }
+        _ = BluxClient.addInAppCustomActionHandler { _, _ in sequence.append(3) }
+
+        for entry in EventHandlers.inAppCustomActionHandlers {
+            entry.handler("any", [:])
+        }
+        XCTAssertEqual(sequence, [1, 2, 3])
+    }
+}

--- a/Tests/BluxClientTests/EventPropertiesTests.swift
+++ b/Tests/BluxClientTests/EventPropertiesTests.swift
@@ -1,0 +1,91 @@
+import XCTest
+@testable import BluxClient
+
+final class EventPropertiesTests: XCTestCase {
+    private let encoder = JSONEncoder()
+    private let decoder = JSONDecoder()
+
+    func testAllFieldsAreOptionalByDefault() {
+        let props = EventProperties()
+        XCTAssertNil(props.itemId)
+        XCTAssertNil(props.section)
+        XCTAssertNil(props.prevSection)
+        XCTAssertNil(props.recommendationId)
+        XCTAssertNil(props.price)
+        XCTAssertNil(props.orderId)
+        XCTAssertNil(props.rating)
+        XCTAssertNil(props.prevPage)
+        XCTAssertNil(props.page)
+        XCTAssertNil(props.position)
+        XCTAssertNil(props.orderAmount)
+        XCTAssertNil(props.paidAmount)
+        XCTAssertNil(props.items)
+    }
+
+    func testSnakeCaseEncoding() throws {
+        let props = EventProperties()
+        props.itemId = "i1"
+        props.prevSection = "p"
+        props.recommendationId = "r"
+        props.orderId = "o"
+        props.prevPage = "pp"
+        props.orderAmount = 1
+        props.paidAmount = 2
+
+        let data = try encoder.encode(props)
+        let dict = try JSONSerialization.jsonObject(with: data) as! [String: Any]
+
+        XCTAssertEqual(dict["item_id"] as? String, "i1")
+        XCTAssertEqual(dict["prev_section"] as? String, "p")
+        XCTAssertEqual(dict["recommendation_id"] as? String, "r")
+        XCTAssertEqual(dict["order_id"] as? String, "o")
+        XCTAssertEqual(dict["prev_page"] as? String, "pp")
+        XCTAssertEqual(dict["order_amount"] as? Double, 1)
+        XCTAssertEqual(dict["paid_amount"] as? Double, 2)
+    }
+
+    func testItemsEncodingShape() throws {
+        let props = EventProperties()
+        props.items = [AddOrderEvent.Item(id: "a", price: 100, quantity: 2)]
+        let data = try encoder.encode(props)
+        let dict = try JSONSerialization.jsonObject(with: data) as! [String: Any]
+        let items = dict["items"] as! [[String: Any]]
+        XCTAssertEqual(items.count, 1)
+        XCTAssertEqual(items[0]["id"] as? String, "a")
+        XCTAssertEqual(items[0]["price"] as? Double, 100)
+        XCTAssertEqual(items[0]["quantity"] as? Int, 2)
+    }
+
+    func testItemEncodingIncludesCustomProps() throws {
+        let item = AddOrderEvent.Item(
+            id: "x",
+            price: 1,
+            quantity: 1,
+            customEventProperties: ["color": .string("blue")]
+        )
+        let data = try encoder.encode(item)
+        let dict = try JSONSerialization.jsonObject(with: data) as! [String: Any]
+        let custom = dict["custom_event_properties"] as! [String: Any]
+        XCTAssertEqual(custom["color"] as? String, "blue")
+    }
+
+    func testItemEncodingOmitsNilCustomProps() throws {
+        let item = AddOrderEvent.Item(id: "x", price: 1, quantity: 1)
+        let data = try encoder.encode(item)
+        let dict = try JSONSerialization.jsonObject(with: data) as! [String: Any]
+        XCTAssertNil(dict["custom_event_properties"])
+    }
+
+    func testRoundTrip() throws {
+        let props = EventProperties()
+        props.itemId = "id"
+        props.price = 1.5
+        props.position = 7
+
+        let data = try encoder.encode(props)
+        let decoded = try decoder.decode(EventProperties.self, from: data)
+        XCTAssertEqual(decoded.itemId, "id")
+        XCTAssertEqual(decoded.price, 1.5)
+        XCTAssertEqual(decoded.position, 7)
+    }
+}

--- a/Tests/BluxClientTests/EventQueueTests.swift
+++ b/Tests/BluxClientTests/EventQueueTests.swift
@@ -1,0 +1,141 @@
+import XCTest
+@testable import BluxClient
+
+/// EventQueue.shared는 SDK 초기화 전후 이벤트 순서를 보장하는 직렬 큐. 싱글톤이라 테스트 간 격리에 주의.
+/// setUp에서 setInitialized + clearPending + 동기 wait로 isInitialized=true 보장 후 매 테스트 진입.
+///
+/// CI(특히 simulator 콜드스타트 직후)에서 `DispatchQueue.global()` 워커가 일시적으로 starvation
+/// 상태가 되어 비동기 task가 수 초 지연될 수 있다. 따라서 wait timeout은 넉넉하게 잡는다 (race 방지).
+/// 단, expectation 자체는 충족 즉시 통과하므로 정상 환경에서 실제 대기 시간이 늘지 않는다.
+final class EventQueueTests: XCTestCase {
+    override func setUp() {
+        super.setUp()
+        EventQueue.shared.setInitialized()
+        EventQueue.shared.clearPending()
+        // EventQueue 내부 큐의 비동기 작업이 모두 dispatch 되도록 sentinel task로 동기화
+        let exp = expectation(description: "drain")
+        EventQueue.shared.addEvent { exp.fulfill() }
+        wait(for: [exp], timeout: 15.0)
+    }
+
+    // MARK: - 동기 task
+
+    func testSynchronousTaskExecutes() {
+        let exp = expectation(description: "task")
+        EventQueue.shared.addEvent {
+            exp.fulfill()
+        }
+        wait(for: [exp], timeout: 15.0)
+    }
+
+    func testMultipleSynchronousTasksExecuteInOrder() {
+        let count = 20
+        var order: [Int] = []
+        let lock = NSLock()
+        let exp = expectation(description: "all done")
+        exp.expectedFulfillmentCount = count
+
+        for i in 0..<count {
+            EventQueue.shared.addEvent {
+                lock.lock(); order.append(i); lock.unlock()
+                exp.fulfill()
+            }
+        }
+
+        wait(for: [exp], timeout: 15.0)
+        XCTAssertEqual(order, Array(0..<count), "Events must run in insertion order")
+    }
+
+    // MARK: - 비동기 task
+
+    func testAsyncTaskCompletesBeforeNext() {
+        var sequence: [String] = []
+        let lock = NSLock()
+        let exp = expectation(description: "both done")
+        exp.expectedFulfillmentCount = 2
+
+        EventQueue.shared.addEvent { (done: @escaping () -> Void) in
+            DispatchQueue.global().asyncAfter(deadline: .now() + 0.1) {
+                lock.lock(); sequence.append("first-finished"); lock.unlock()
+                done()
+                exp.fulfill()
+            }
+        }
+        EventQueue.shared.addEvent {
+            lock.lock(); sequence.append("second-started"); lock.unlock()
+            exp.fulfill()
+        }
+
+        wait(for: [exp], timeout: 20.0)
+        XCTAssertEqual(sequence, ["first-finished", "second-started"],
+                       "Second task must wait for first's done()")
+    }
+
+    /// done() 미호출 시 큐가 영구 락된다는 사실은 코드 리뷰로 자명하지만
+    /// 싱글톤 EventQueue.shared의 isProcessing을 회복할 방법이 없어 다른 테스트를 망가뜨린다.
+    /// 따라서 이 시나리오는 단위 테스트로 검증하지 않는다.
+
+    // MARK: - clearPending
+
+    func testClearPendingDropsWaitingTasks() {
+        let firstExp = expectation(description: "first")
+        let droppedExp = expectation(description: "dropped (should not run)")
+        droppedExp.isInverted = true
+
+        // 첫 task를 충분히 길게 잡아 두 번째가 대기 상태로 들어가게 함. CI 부하 시 race 방지를 위해 buffer 여유.
+        EventQueue.shared.addEvent { (done: @escaping () -> Void) in
+            DispatchQueue.global().asyncAfter(deadline: .now() + 0.6) {
+                firstExp.fulfill()
+                done()
+            }
+        }
+        EventQueue.shared.addEvent {
+            droppedExp.fulfill()
+        }
+
+        // 첫 task가 실행 중이고 두 번째가 대기 중일 때 clearPending
+        DispatchQueue.global().asyncAfter(deadline: .now() + 0.2) {
+            EventQueue.shared.clearPending()
+        }
+
+        wait(for: [firstExp, droppedExp], timeout: 20.0)
+    }
+
+    func testClearPendingDoesNotResetInitialized() {
+        // clearPending 후에도 신규 addEvent는 정상 처리돼야 함
+        EventQueue.shared.clearPending()
+        let exp = expectation(description: "new task after clear")
+        EventQueue.shared.addEvent {
+            exp.fulfill()
+        }
+        wait(for: [exp], timeout: 15.0)
+    }
+
+    // MARK: - shared 싱글톤
+
+    func testSharedIsSingleton() {
+        XCTAssertTrue(EventQueue.shared === EventQueue.shared)
+    }
+
+    // MARK: - setInitialized idempotency
+
+    // setInitialized가 중복 호출돼도 진행 중인 task를 깨뜨리지 않아야 한다.
+    func testSetInitializedIsIdempotent() {
+        EventQueue.shared.setInitialized()
+        EventQueue.shared.setInitialized()
+        EventQueue.shared.setInitialized()
+
+        let exp = expectation(description: "task after multi setInitialized")
+        EventQueue.shared.addEvent { exp.fulfill() }
+        wait(for: [exp], timeout: 15.0)
+    }
+
+    // clearPending 후에도 isInitialized 상태가 유지되어 신규 addEvent가 정상 처리.
+    func testClearPendingPreservesInitialized() {
+        EventQueue.shared.clearPending()
+
+        let exp = expectation(description: "task after clearPending")
+        EventQueue.shared.addEvent { exp.fulfill() }
+        wait(for: [exp], timeout: 15.0)
+    }
+}

--- a/Tests/BluxClientTests/EventRequestTests.swift
+++ b/Tests/BluxClientTests/EventRequestTests.swift
@@ -1,0 +1,27 @@
+import XCTest
+@testable import BluxClient
+
+final class EventRequestTests: XCTestCase {
+    func testEmptyRequestHasNoEvents() {
+        let req = EventRequest()
+        XCTAssertEqual(req.events.count, 0)
+        XCTAssertEqual(req.getPayload().count, 0)
+    }
+
+    func testAppendingEvents() {
+        let req = EventRequest()
+        req.events.append(Event(eventType: "a"))
+        req.events.append(Event(eventType: "b"))
+        XCTAssertEqual(req.getPayload().count, 2)
+        XCTAssertEqual(req.getPayload()[0].eventType, "a")
+        XCTAssertEqual(req.getPayload()[1].eventType, "b")
+    }
+
+    func testGetPayloadIgnoresIsTestFlag() {
+        let req = EventRequest()
+        req.events.append(Event(eventType: "x"))
+        // isTest 파라미터는 현재 구현에서 사용되지 않음
+        XCTAssertEqual(req.getPayload(isTest: true).count, 1)
+        XCTAssertEqual(req.getPayload(isTest: false).count, 1)
+    }
+}

--- a/Tests/BluxClientTests/EventServiceBackoffSpecTests.swift
+++ b/Tests/BluxClientTests/EventServiceBackoffSpecTests.swift
@@ -1,0 +1,90 @@
+import XCTest
+@testable import BluxClient
+
+/// 회귀 방지: EventService 폴링 백오프 알고리즘의 spec lock-in.
+///
+/// Fix commit: 91df32b "fix: 이벤트 폴링 백오프 상한을 의도대로 1일로 정정 (#80)"
+///
+/// 이전 버그: `cached > 24h ? cached : cached * 2`는 24h 초과 상태에서만 증가를 멈춰,
+/// 직전 값 12h → 24h → 48h로 한 번 더 두 배된 뒤에야 상한에 걸렸다 (실효 최댓값 48h).
+/// 또 서버가 DISABLED_POLL_DELAY 같은 긴 값(예: 10일)을 의도적으로 내려줘도
+/// 다음 실패 시 doubling되어 의도가 훼손될 위험이 있었다.
+///
+/// 수정된 알고리즘 (EventService.swift:111-115):
+///   if cached >= dayCapMs { cached }              // 그대로 유지
+///   else { min(cached * 2, dayCapMs) }            // 2배 (상한 1일)
+///
+/// `cachedPollDelayMs`는 private static + 비동기 폴링 path 안에서만 갱신되어
+/// 외부에서 직접 호출할 수 있는 seam이 없다. 동일 알고리즘을 spec helper로
+/// 미러링해 락-인하면, 알고리즘이 변경될 때 helper도 같이 변경해야 하므로
+/// 의도된 변경임을 명시하게 된다.
+final class EventServiceBackoffSpecTests: XCTestCase {
+    private let dayCapMs = 1000 * 60 * 60 * 24
+    private let tenDaysMs = 10 * 1000 * 60 * 60 * 24
+
+    /// EventService.swift:111-115 백오프 로직 spec (fix commit 91df32b).
+    private func applyErrorBackoff(currentDelayMs: Int) -> Int {
+        return currentDelayMs >= dayCapMs
+            ? currentDelayMs
+            : min(currentDelayMs * 2, dayCapMs)
+    }
+
+    // MARK: - 24h 미만: doubling
+
+    func test_10s_doublesTo_20s() {
+        XCTAssertEqual(applyErrorBackoff(currentDelayMs: 10_000), 20_000)
+    }
+
+    func test_1minute_doublesTo_2minutes() {
+        XCTAssertEqual(applyErrorBackoff(currentDelayMs: 60_000), 120_000)
+    }
+
+    func test_initialPollDelay_10s_firstBackoff_20s() {
+        // EventService.cachedPollDelayMs 초기값 10_000과 동일.
+        XCTAssertEqual(applyErrorBackoff(currentDelayMs: 10_000), 20_000)
+    }
+
+    func test_12h_doublesTo_24hCap() {
+        // 12h * 2 = 24h, min(24h, 24h) = 24h
+        let twelveH = 12 * 60 * 60 * 1000
+        XCTAssertEqual(applyErrorBackoff(currentDelayMs: twelveH), dayCapMs)
+    }
+
+    func test_13h_cappedAt_24h() {
+        // 13h * 2 = 26h, min(26h, 24h) = 24h
+        let thirteenH = 13 * 60 * 60 * 1000
+        XCTAssertEqual(applyErrorBackoff(currentDelayMs: thirteenH), dayCapMs)
+    }
+
+    func test_24hMinus1ms_doublesAndCappedAt_24h() {
+        // boundary: 24h - 1ms는 dayCap 미만이므로 doubling 적용 (cap에 흡수)
+        let almostDay = dayCapMs - 1
+        XCTAssertEqual(applyErrorBackoff(currentDelayMs: almostDay), dayCapMs)
+    }
+
+    // MARK: - 24h 이상: 보존 (회귀 방지의 핵심)
+
+    func test_exactly_24h_isPreservedNotDoubled() {
+        // boundary: 24h 정확히 dayCap 이상 → 유지 (이전 버그에서는 다음 step에서 48h로 증가했음)
+        XCTAssertEqual(applyErrorBackoff(currentDelayMs: dayCapMs), dayCapMs)
+    }
+
+    func test_24hPlus1ms_isPreservedNotShortened() {
+        // 회귀 핵심: 이전 잘못된 구현(`coerceAtMost(24h)` 무조건 적용)이라면 24h로 단축됐을 값.
+        // 새 알고리즘은 그대로 유지.
+        let dayCapPlus1ms = dayCapMs + 1
+        XCTAssertEqual(applyErrorBackoff(currentDelayMs: dayCapPlus1ms), dayCapPlus1ms)
+    }
+
+    func test_DISABLED_POLL_DELAY_10days_isPreserved() {
+        // 서버가 "이 디바이스는 당분간 폴링하지 마라"는 명시적 지시로 10일을 내려줌.
+        // 클라이언트가 24h로 단축하면 서버 의도 훼손. 그대로 유지해야 함.
+        XCTAssertEqual(applyErrorBackoff(currentDelayMs: tenDaysMs), tenDaysMs)
+    }
+
+    func test_largeValue_neverGrows() {
+        // 24h 이상은 doubling 안 함 → Int overflow trap 위험도 제거됨.
+        let largeMs = 100 * 24 * 60 * 60 * 1000  // 100일
+        XCTAssertEqual(applyErrorBackoff(currentDelayMs: largeMs), largeMs)
+    }
+}

--- a/Tests/BluxClientTests/EventServiceTests.swift
+++ b/Tests/BluxClientTests/EventServiceTests.swift
@@ -1,0 +1,86 @@
+import XCTest
+@testable import BluxClient
+
+/// EventService는 정적 상태(pendingEvents, batchWorkItem, pollTimer)를 가진다.
+/// URLSession.shared를 사용해 실제 네트워크 호출이 일어나므로 발신 자체는 mock 불가.
+/// 검증 가능한 부분:
+/// - sendEvent에 빈 배열을 넘기면 즉시 polling 경로로 분기 (no batching)
+/// - clearPendingBatch가 안전하게 호출됨
+/// - flush가 안전하게 호출됨
+/// - EventWrapper Codable shape (서버 contract)
+final class EventServiceTests: XCTestCase {
+    private var guardian: SdkStateGuard!
+
+    override func setUp() {
+        super.setUp()
+        guardian = SdkStateGuard()
+        guardian.clear()
+        EventService.clearPendingBatch()
+    }
+
+    override func tearDown() {
+        EventService.clearPendingBatch()
+        guardian.restore()
+        guardian = nil
+        super.tearDown()
+    }
+
+    // MARK: - clearPendingBatch (안전성)
+
+    func testClearPendingBatchCanBeCalledRepeatedly() {
+        EventService.clearPendingBatch()
+        EventService.clearPendingBatch()
+        EventService.clearPendingBatch()
+    }
+
+    func testFlushCanBeCalledOnEmptyBuffer() {
+        EventService.clearPendingBatch()
+        EventService.flush()
+    }
+
+    func testSendEventEmptyBypassesBatch() {
+        // 빈 배열은 즉시 polling 경로 (performRequest)로 분기.
+        // ID가 없어 EventQueue 안에서 early return → 부작용 없음. 크래시만 안 나면 통과.
+        EventService.sendEvent([])
+    }
+
+    func testSendEventBatchesSingleEvent() {
+        // SdkConfig IDs가 없으니 EventQueue 내 early return.
+        // 100ms batch window + 디스패치 여유 → 0.4s 대기. 부작용 검증은 어렵고 크래시 없는지만 확인.
+        let event = Event(eventType: "x")
+        EventService.sendEvent([event])
+
+        let exp = expectation(description: "batch flush window")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.4) { exp.fulfill() }
+        wait(for: [exp], timeout: 2.0)
+
+        EventService.clearPendingBatch()
+    }
+
+    // MARK: - EventWrapper 인코딩 (서버 contract)
+
+    func testEventWrapperEncodesEventsAndDeviceId() throws {
+        SdkConfig.sessionId = "S"
+        let events = [Event(eventType: "visit"), Event(eventType: "click")]
+        let wrapper = EventWrapper(events: events, deviceId: "D-1")
+
+        let data = try JSONEncoder().encode(wrapper)
+        let dict = try JSONSerialization.jsonObject(with: data) as! [String: Any]
+
+        XCTAssertEqual(dict["device_id"] as? String, "D-1")
+        let evts = dict["events"] as! [[String: Any]]
+        XCTAssertEqual(evts.count, 2)
+        XCTAssertEqual(evts[0]["event_type"] as? String, "visit")
+        XCTAssertEqual(evts[1]["event_type"] as? String, "click")
+    }
+
+    func testEventWrapperEmptyEventsArray() throws {
+        let wrapper = EventWrapper(events: [], deviceId: "D-2")
+        let data = try JSONEncoder().encode(wrapper)
+        let dict = try JSONSerialization.jsonObject(with: data) as! [String: Any]
+
+        let evts = dict["events"] as! [[String: Any]]
+        XCTAssertTrue(evts.isEmpty)
+        XCTAssertEqual(dict["device_id"] as? String, "D-2")
+    }
+}

--- a/Tests/BluxClientTests/EventServiceTests.swift
+++ b/Tests/BluxClientTests/EventServiceTests.swift
@@ -16,10 +16,15 @@ final class EventServiceTests: XCTestCase {
         guardian = SdkStateGuard()
         guardian.clear()
         EventService.clearPendingBatch()
+        EventQueue.shared.setInitialized()
+        EventQueue.shared.clearPending()
     }
 
     override func tearDown() {
         EventService.clearPendingBatch()
+        // EventQueue.shared 싱글톤이라 이 파일이 setInitialized한 상태가 후속 테스트에 누수되면
+        // 영구 손상으로 이어질 수 있다. 대기 task를 비워서 다음 테스트가 깨끗한 상태로 진입하도록.
+        EventQueue.shared.clearPending()
         guardian.restore()
         guardian = nil
         super.tearDown()
@@ -82,5 +87,26 @@ final class EventServiceTests: XCTestCase {
         let evts = dict["events"] as! [[String: Any]]
         XCTAssertTrue(evts.isEmpty)
         XCTAssertEqual(dict["device_id"] as? String, "D-2")
+    }
+
+    // SdkConfig IDs가 nil인 상태에서 sendEvent가 호출되면 EventQueue 안에서 early return + done()이
+    // 호출되어 후속 task가 starvation되지 않아야 한다.
+    // (회귀: HTTPClient.invalidRequest 시 completion 미호출 → done 미호출 → EventQueue 영구 정지)
+    func testSendEventDoesNotStarveEventQueueWhenNoIds() {
+        EventQueue.shared.setInitialized()
+        EventQueue.shared.clearPending()
+
+        let drain = expectation(description: "drain")
+        EventQueue.shared.addEvent { drain.fulfill() }
+        wait(for: [drain], timeout: 2.0)
+
+        EventService.sendEvent([Event(eventType: "x")])
+
+        // 100ms batch window + EventQueue dispatch + invalidRequest 경로의 done() 호출. CI 여유로 0.6s.
+        let postBatch = expectation(description: "post-batch sentinel")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.6) {
+            EventQueue.shared.addEvent { postBatch.fulfill() }
+        }
+        wait(for: [postBatch], timeout: 5.0)
     }
 }

--- a/Tests/BluxClientTests/EventTests.swift
+++ b/Tests/BluxClientTests/EventTests.swift
@@ -1,0 +1,307 @@
+import XCTest
+@testable import BluxClient
+
+/// Event 모델은 서버 `/v2/collect-events`의 `events[]` 요소와 매칭.
+/// 서버 schema: { event_type (필수), captured_at (필수), event_properties?, custom_event_properties?, internal_event_properties? }
+/// SDK는 추가로 blux_id, device_id, user_id, session_id를 같이 보냄 (Event level은 서버 wrapper의 device_id로도 식별됨).
+final class EventTests: XCTestCase {
+    private var guardian: SdkStateGuard!
+
+    override func setUp() {
+        super.setUp()
+        guardian = SdkStateGuard()
+        guardian.clear()
+    }
+
+    override func tearDown() {
+        guardian.restore()
+        guardian = nil
+        super.tearDown()
+    }
+
+    // MARK: - Initialization
+
+    func testInitWithEventTypeStoresType() {
+        let event = Event(eventType: "page_view")
+        XCTAssertEqual(event.eventType, "page_view")
+    }
+
+    func testInitGeneratesISO8601CapturedAt() {
+        let event = Event(eventType: "visit")
+        XCTAssertNotNil(ISO8601DateFormatter().date(from: event.capturedAt),
+                        "capturedAt must be ISO8601 parseable")
+    }
+
+    func testInitInheritsSdkConfigIds() {
+        SdkConfig.bluxIdInUserDefaults = "blux-1"
+        SdkConfig.deviceIdInUserDefaults = "device-1"
+        SdkConfig.userIdInUserDefaults = "user-1"
+
+        let event = Event(eventType: "x")
+        XCTAssertEqual(event.bluxId, "blux-1")
+        XCTAssertEqual(event.deviceId, "device-1")
+        XCTAssertEqual(event.userId, "user-1")
+    }
+
+    func testInitInheritsSessionId() {
+        SdkConfig.sessionId = "fixed-session"
+        let event = Event(eventType: "x")
+        XCTAssertEqual(event.sessionId, "fixed-session")
+    }
+
+    func testInitWhenIdsAreNil() {
+        let event = Event(eventType: "x")
+        XCTAssertNil(event.bluxId)
+        XCTAssertNil(event.deviceId)
+        XCTAssertNil(event.userId)
+        XCTAssertNotNil(event.sessionId)
+    }
+
+    func testInitDefaultsToEmptyEventProperties() {
+        let event = Event(eventType: "x")
+        XCTAssertNil(event.eventProperties.itemId)
+        XCTAssertNil(event.eventProperties.price)
+    }
+
+    // MARK: - Setters: itemId
+
+    func testSetItemIdValid() throws {
+        let event = Event(eventType: "x")
+        try event.setItemId("item-123")
+        XCTAssertEqual(event.eventProperties.itemId, "item-123")
+    }
+
+    func testSetItemIdEmptyThrows() {
+        let event = Event(eventType: "x")
+        XCTAssertThrowsError(try event.setItemId(""))
+    }
+
+    func testSetItemIdTooLongThrows() {
+        let longId = String(repeating: "a", count: 501)
+        let event = Event(eventType: "x")
+        XCTAssertThrowsError(try event.setItemId(longId))
+    }
+
+    func testSetItemId500CharsAllowed() throws {
+        let id500 = String(repeating: "a", count: 500)
+        let event = Event(eventType: "x")
+        try event.setItemId(id500)
+        XCTAssertEqual(event.eventProperties.itemId?.count, 500)
+    }
+
+    // MARK: - Setters: price
+
+    func testSetPriceValid() throws {
+        let event = Event(eventType: "x")
+        try event.setPrice(1000)
+        XCTAssertEqual(event.eventProperties.price, 1000)
+    }
+
+    func testSetPriceZeroAllowed() throws {
+        let event = Event(eventType: "x")
+        try event.setPrice(0)
+        XCTAssertEqual(event.eventProperties.price, 0)
+    }
+
+    func testSetPriceNegativeThrows() {
+        let event = Event(eventType: "x")
+        XCTAssertThrowsError(try event.setPrice(-0.01))
+    }
+
+    func testSetPriceNilLeavesUnset() throws {
+        let event = Event(eventType: "x")
+        try event.setPrice(nil)
+        XCTAssertNil(event.eventProperties.price)
+    }
+
+    // MARK: - Setters: orderId, page
+
+    func testSetOrderIdValid() throws {
+        let event = Event(eventType: "x")
+        try event.setOrderId("ORD-001")
+        XCTAssertEqual(event.eventProperties.orderId, "ORD-001")
+    }
+
+    func testSetOrderIdEmptyThrows() {
+        let event = Event(eventType: "x")
+        XCTAssertThrowsError(try event.setOrderId(""))
+    }
+
+    func testSetOrderIdNilLeavesUnset() throws {
+        let event = Event(eventType: "x")
+        try event.setOrderId(nil)
+        XCTAssertNil(event.eventProperties.orderId)
+    }
+
+    func testSetPageValid() throws {
+        let event = Event(eventType: "x")
+        try event.setPage("home")
+        XCTAssertEqual(event.eventProperties.page, "home")
+    }
+
+    func testSetPageEmptyThrows() {
+        let event = Event(eventType: "x")
+        XCTAssertThrowsError(try event.setPage(""))
+    }
+
+    // MARK: - Setters: rating, amounts (no validation)
+
+    func testSetRatingPersists() throws {
+        let event = Event(eventType: "x")
+        try event.setRating(4.5)
+        XCTAssertEqual(event.eventProperties.rating, 4.5)
+    }
+
+    func testSetRatingNilLeavesUnset() throws {
+        let event = Event(eventType: "x")
+        try event.setRating(nil)
+        XCTAssertNil(event.eventProperties.rating)
+    }
+
+    func testSetOrderAmountPersists() throws {
+        let event = Event(eventType: "x")
+        try event.setOrderAmount(99.99)
+        XCTAssertEqual(event.eventProperties.orderAmount, 99.99)
+    }
+
+    func testSetPaidAmountPersists() throws {
+        let event = Event(eventType: "x")
+        try event.setPaidAmount(50.0)
+        XCTAssertEqual(event.eventProperties.paidAmount, 50.0)
+    }
+
+    // MARK: - Setters: items
+
+    func testSetItemsPersists() throws {
+        let event = Event(eventType: "x")
+        let items = [AddOrderEvent.Item(id: "a", price: 1, quantity: 1)]
+        try event.setItems(items)
+        XCTAssertEqual(event.eventProperties.items?.count, 1)
+        XCTAssertEqual(event.eventProperties.items?.first?.id, "a")
+    }
+
+    func testSetItemsNilLeavesUnset() throws {
+        let event = Event(eventType: "x")
+        try event.setItems(nil)
+        XCTAssertNil(event.eventProperties.items)
+    }
+
+    // MARK: - Setter chaining is fluent
+
+    func testFluentChaining() throws {
+        let event = try Event(eventType: "order")
+            .setOrderId("O-1")
+            .setOrderAmount(100)
+            .setPaidAmount(80)
+
+        XCTAssertEqual(event.eventProperties.orderId, "O-1")
+        XCTAssertEqual(event.eventProperties.orderAmount, 100)
+        XCTAssertEqual(event.eventProperties.paidAmount, 80)
+    }
+
+    // MARK: - Custom / Internal properties
+
+    func testSetCustomEventProperties() {
+        let event = Event(eventType: "x")
+        event.setCustomEventProperties(["k": .string("v")])
+        XCTAssertNotNil(event.customEventProperties)
+        if case .string("v")? = event.customEventProperties?["k"] {} else {
+            XCTFail("custom property k mismatch")
+        }
+    }
+
+    func testSetCustomEventPropertiesNilClears() {
+        let event = Event(eventType: "x")
+        event.setCustomEventProperties(["k": .int(1)])
+        event.setCustomEventProperties(nil)
+        XCTAssertNil(event.customEventProperties)
+    }
+
+    func testSetInternalEventProperties() {
+        let event = Event(eventType: "x")
+        event.setInternalEventProperties(["url": .string("/foo")])
+        if case .string("/foo")? = event.internalEventProperties?["url"] {} else {
+            XCTFail()
+        }
+    }
+
+    // MARK: - setEventProperties
+
+    func testSetEventPropertiesReplacesContainer() {
+        let event = Event(eventType: "x")
+        let props = EventProperties()
+        props.itemId = "from-replacement"
+        event.setEventProperties(props)
+        XCTAssertEqual(event.eventProperties.itemId, "from-replacement")
+    }
+
+    func testSetEventPropertiesNilLeavesExisting() throws {
+        let event = Event(eventType: "x")
+        try event.setItemId("kept")
+        event.setEventProperties(nil)
+        XCTAssertEqual(event.eventProperties.itemId, "kept")
+    }
+
+    // MARK: - Encoding (서버 contract 검증)
+
+    func testEncodingProducesSnakeCaseKeys() throws {
+        SdkConfig.bluxIdInUserDefaults = "B"
+        SdkConfig.deviceIdInUserDefaults = "D"
+        SdkConfig.userIdInUserDefaults = "U"
+        SdkConfig.sessionId = "S"
+
+        let event = try Event(eventType: "page_view").setPage("home")
+        let data = try JSONEncoder().encode(event)
+        let dict = try JSONSerialization.jsonObject(with: data) as! [String: Any]
+
+        XCTAssertEqual(dict["event_type"] as? String, "page_view")
+        XCTAssertEqual(dict["blux_id"] as? String, "B")
+        XCTAssertEqual(dict["device_id"] as? String, "D")
+        XCTAssertEqual(dict["user_id"] as? String, "U")
+        XCTAssertEqual(dict["session_id"] as? String, "S")
+        XCTAssertNotNil(dict["captured_at"])
+        XCTAssertNotNil(dict["event_properties"])
+
+        let props = dict["event_properties"] as! [String: Any]
+        XCTAssertEqual(props["page"] as? String, "home")
+    }
+
+    func testEncodingOmitsNilCustomAndInternalProps() throws {
+        let event = Event(eventType: "x")
+        let data = try JSONEncoder().encode(event)
+        let dict = try JSONSerialization.jsonObject(with: data) as! [String: Any]
+        // JSONEncoder의 기본 동작: nil은 키 누락 (Swift Optional)
+        XCTAssertNil(dict["custom_event_properties"])
+        XCTAssertNil(dict["internal_event_properties"])
+    }
+
+    func testEncodingIncludesCustomEventProperties() throws {
+        let event = Event(eventType: "x")
+        event.setCustomEventProperties(["color": .string("red"), "qty": .int(3)])
+        let data = try JSONEncoder().encode(event)
+        let dict = try JSONSerialization.jsonObject(with: data) as! [String: Any]
+        let custom = dict["custom_event_properties"] as! [String: Any]
+        XCTAssertEqual(custom["color"] as? String, "red")
+        XCTAssertEqual(custom["qty"] as? Int, 3)
+    }
+
+    // MARK: - Description
+
+    func testDescriptionContainsEventType() {
+        let event = Event(eventType: "page_view")
+        XCTAssertTrue(event.description.contains("page_view"))
+    }
+
+    func testDescriptionSkipsNullStrings() {
+        // bluxId가 "null" 문자열이면 description에서 빠짐 (서버에서 null sentinel 보낼 때 노이즈 방지)
+        let event = Event(eventType: "x")
+        event.bluxId = "null"
+        XCTAssertFalse(event.description.contains("bluxId: null"))
+    }
+
+    func testDescriptionShowsCustomProps() {
+        let event = Event(eventType: "x")
+        event.setCustomEventProperties(["k": .string("v")])
+        XCTAssertTrue(event.description.contains("customEventProperties"))
+    }
+}

--- a/Tests/BluxClientTests/HTTPClientTests.swift
+++ b/Tests/BluxClientTests/HTTPClientTests.swift
@@ -1,0 +1,135 @@
+import XCTest
+@testable import BluxClient
+
+/// URLSession.shared를 직접 사용하므로 정상 경로 mocking은 어렵다.
+/// 검증 가능한 경로:
+/// - clientId가 nil이면 invalidRequest 에러로 즉시 completion
+/// - HTTPError 케이스 식별
+/// - setStage가 base URL을 변경
+final class HTTPClientTests: XCTestCase {
+    private var guardian: SdkStateGuard!
+
+    override func setUp() {
+        super.setUp()
+        guardian = SdkStateGuard()
+        guardian.clear()
+    }
+
+    override func tearDown() {
+        guardian.restore()
+        guardian = nil
+        super.tearDown()
+    }
+
+    func testSharedIsSingleton() {
+        XCTAssertTrue(HTTPClient.shared === HTTPClient.shared)
+    }
+
+    // MARK: - invalidRequest 경로 (clientId 없음)
+
+    func testGetReturnsInvalidRequestWhenNoClientId() {
+        let exp = expectation(description: "completion called")
+        var receivedError: Error?
+
+        HTTPClient.shared.get(path: "/x") { (_: EmptyResponse?, error) in
+            receivedError = error
+            exp.fulfill()
+        }
+
+        wait(for: [exp], timeout: 2.0)
+        assertInvalidRequest(receivedError)
+    }
+
+    func testPostReturnsInvalidRequestWhenNoClientId() {
+        let exp = expectation(description: "completion called")
+        var receivedError: Error?
+
+        HTTPClient.shared.post(path: "/x", body: EmptyResponse()) { (_: EmptyResponse?, error) in
+            receivedError = error
+            exp.fulfill()
+        }
+
+        wait(for: [exp], timeout: 2.0)
+        assertInvalidRequest(receivedError)
+    }
+
+    func testPutReturnsInvalidRequestWhenNoClientId() {
+        let exp = expectation(description: "completion called")
+        var receivedError: Error?
+
+        HTTPClient.shared.put(path: "/x", body: EmptyResponse()) { (_: EmptyResponse?, error) in
+            receivedError = error
+            exp.fulfill()
+        }
+
+        wait(for: [exp], timeout: 2.0)
+        assertInvalidRequest(receivedError)
+    }
+
+    func testPatchReturnsInvalidRequestWhenNoClientId() {
+        let exp = expectation(description: "completion called")
+        var receivedError: Error?
+
+        HTTPClient.shared.patch(path: "/x", body: EmptyResponse()) { (_: EmptyResponse?, error) in
+            receivedError = error
+            exp.fulfill()
+        }
+
+        wait(for: [exp], timeout: 2.0)
+        assertInvalidRequest(receivedError)
+    }
+
+    private func assertInvalidRequest(_ error: Error?, file: StaticString = #file, line: UInt = #line) {
+        guard let httpError = error as? HTTPClient.HTTPError else {
+            XCTFail("Expected HTTPError, got \(String(describing: error))", file: file, line: line)
+            return
+        }
+        if case .invalidRequest = httpError {
+            return
+        }
+        XCTFail("Expected .invalidRequest, got \(httpError)", file: file, line: line)
+    }
+
+    // MARK: - HTTPError 케이스
+
+    func testHTTPErrorServerSideErrorHoldsStatusCode() {
+        let error = HTTPClient.HTTPError.serverSideError(503)
+        if case let .serverSideError(code) = error {
+            XCTAssertEqual(code, 503)
+        } else {
+            XCTFail()
+        }
+    }
+
+    func testHTTPErrorTransportErrorWrapsUnderlying() {
+        struct UnderlyingError: Error {}
+        let error = HTTPClient.HTTPError.transportError(UnderlyingError())
+        if case .transportError = error {
+            // OK
+        } else {
+            XCTFail()
+        }
+    }
+
+    // MARK: - setStage
+
+    func testSetStageDoesNotCrash() {
+        // setStage는 단순 baseURL 교체. private API라 외부에서 base URL을 직접 검증할 수 없으니
+        // 호출 자체가 안전한지만 확인.
+        HTTPClient.shared.setStage(.local)
+        HTTPClient.shared.setStage(.dev)
+        HTTPClient.shared.setStage(.stg)
+        HTTPClient.shared.setStage(.prod)
+    }
+
+    // MARK: - EmptyResponse
+
+    func testEmptyResponseEncodesToEmptyJSON() throws {
+        let data = try JSONEncoder().encode(EmptyResponse())
+        XCTAssertEqual(String(data: data, encoding: .utf8), "{}")
+    }
+
+    func testEmptyResponseDecodesFromEmptyJSON() throws {
+        _ = try JSONDecoder().decode(EmptyResponse.self, from: "{}".data(using: .utf8)!)
+    }
+}

--- a/Tests/BluxClientTests/InappServiceTests.swift
+++ b/Tests/BluxClientTests/InappServiceTests.swift
@@ -1,0 +1,47 @@
+import XCTest
+@testable import BluxClient
+
+final class InappServiceTests: XCTestCase {
+    // 표시 중인 인앱이 없는 baseline에서도 cleanup 함수들이 안전 호출되어야 한다.
+    // signOut / credential 전환 경로에서 무조건 호출되므로 회귀 시 signOut 자체가 깨진다.
+    func testCleanupIsSafeWhenNothingShown() {
+        InappService.dismissCurrentInApp()
+        InappService.clearInappQueue()
+    }
+
+    // handleInappResponse가 백그라운드 스레드에서 호출돼도 main으로 dispatch되어
+    // webViewQueue 조작이 안전해야 한다. (회귀: race condition으로 "Index out of range" 크래시)
+    func testHandleInappResponseSafeFromBackgroundThread() {
+        let response = InappDispatchResponse(
+            notificationId: "n",
+            htmlString: "<html></html>",
+            inappId: "i",
+            baseUrl: "https://cdn.blux.ai"
+        )
+
+        let exp = expectation(description: "no crash from background dispatch")
+        DispatchQueue.global().async {
+            InappService.handleInappResponse(response)
+            exp.fulfill()
+        }
+        wait(for: [exp], timeout: 2.0)
+
+        let drain = expectation(description: "main drain")
+        DispatchQueue.main.async {
+            InappService.clearInappQueue()
+            InappService.dismissCurrentInApp()
+            drain.fulfill()
+        }
+        wait(for: [drain], timeout: 2.0)
+    }
+
+    func testHandleInappResponseRejectsInvalidBaseURL() {
+        let response = InappDispatchResponse(
+            notificationId: "n",
+            htmlString: "<html></html>",
+            inappId: "i",
+            baseUrl: ""
+        )
+        InappService.handleInappResponse(response)
+    }
+}

--- a/Tests/BluxClientTests/LoggerTests.swift
+++ b/Tests/BluxClientTests/LoggerTests.swift
@@ -1,0 +1,46 @@
+import XCTest
+@testable import BluxClient
+
+final class LoggerTests: XCTestCase {
+    func testLogLevelRawValues() {
+        XCTAssertEqual(LogLevel.none.rawValue, 0)
+        XCTAssertEqual(LogLevel.error.rawValue, 1)
+        XCTAssertEqual(LogLevel.verbose.rawValue, 5)
+    }
+
+    func testLogLevelDescription() {
+        XCTAssertEqual(LogLevel.none.description, "none")
+        XCTAssertEqual(LogLevel.error.description, "error")
+        XCTAssertEqual(LogLevel.verbose.description, "verbose")
+    }
+
+    func testLogLevelOrdering() {
+        XCTAssertLessThan(LogLevel.none.rawValue, LogLevel.error.rawValue)
+        XCTAssertLessThan(LogLevel.error.rawValue, LogLevel.verbose.rawValue)
+    }
+
+    func testLoggerEmitsWithoutCrashing() {
+        // Logger는 os_log 호출만 하고 반환값이 없으니 크래시만 없으면 통과
+        Logger.error("test error")
+        Logger.verbose("test verbose")
+    }
+
+    func testLoggerRespectsLogLevelThresholdAtNone() {
+        let saved = SdkConfig.logLevel
+        defer { SdkConfig.logLevel = saved }
+
+        SdkConfig.logLevel = .none
+        // 둘 다 호출되지만 출력만 안 됨; 크래시 검증
+        Logger.error("should be suppressed")
+        Logger.verbose("should be suppressed")
+    }
+
+    func testLoggerRespectsLogLevelThresholdAtError() {
+        let saved = SdkConfig.logLevel
+        defer { SdkConfig.logLevel = saved }
+
+        SdkConfig.logLevel = .error
+        Logger.error("emitted")
+        Logger.verbose("suppressed")
+    }
+}

--- a/Tests/BluxClientTests/NSNumberClassifierTests.swift
+++ b/Tests/BluxClientTests/NSNumberClassifierTests.swift
@@ -1,0 +1,133 @@
+import XCTest
+@testable import BluxClient
+
+final class NSNumberClassifierTests: XCTestCase {
+    // MARK: - Bool
+
+    func testClassifyBoolTrue() {
+        guard case let .bool(value)? = NSNumberClassifier.classify(true) else {
+            XCTFail("Expected .bool")
+            return
+        }
+        XCTAssertTrue(value)
+    }
+
+    func testClassifyBoolFalse() {
+        guard case let .bool(value)? = NSNumberClassifier.classify(false) else {
+            XCTFail("Expected .bool")
+            return
+        }
+        XCTAssertFalse(value)
+    }
+
+    func testClassifyNSNumberFromBool() {
+        guard case let .bool(value)? = NSNumberClassifier.classify(NSNumber(value: true)) else {
+            XCTFail("Expected .bool")
+            return
+        }
+        XCTAssertTrue(value)
+    }
+
+    // MARK: - Int
+
+    func testClassifyInt() {
+        guard case let .int(value)? = NSNumberClassifier.classify(42) else {
+            XCTFail("Expected .int")
+            return
+        }
+        XCTAssertEqual(value, 42)
+    }
+
+    func testClassifyNegativeInt() {
+        guard case let .int(value)? = NSNumberClassifier.classify(-7) else {
+            XCTFail("Expected .int")
+            return
+        }
+        XCTAssertEqual(value, -7)
+    }
+
+    func testClassifyZeroInt() {
+        guard case let .int(value)? = NSNumberClassifier.classify(0) else {
+            XCTFail("Expected .int")
+            return
+        }
+        XCTAssertEqual(value, 0)
+    }
+
+    func testClassifyLargeInt() {
+        let big = Int.max
+        guard case let .int(value)? = NSNumberClassifier.classify(big) else {
+            XCTFail("Expected .int")
+            return
+        }
+        XCTAssertEqual(value, big)
+    }
+
+    // MARK: - Double
+
+    func testClassifyDouble() {
+        guard case let .double(value)? = NSNumberClassifier.classify(3.14) else {
+            XCTFail("Expected .double")
+            return
+        }
+        XCTAssertEqual(value, 3.14, accuracy: 0.0001)
+    }
+
+    func testClassifyFloat() {
+        let f: Float = 1.5
+        guard case let .double(value)? = NSNumberClassifier.classify(f) else {
+            XCTFail("Expected .double for Float, got: \(String(describing: NSNumberClassifier.classify(f)))")
+            return
+        }
+        XCTAssertEqual(value, 1.5, accuracy: 0.0001)
+    }
+
+    func testClassifyZeroDouble() {
+        guard case let .double(value)? = NSNumberClassifier.classify(0.0 as Double) else {
+            XCTFail("Expected .double")
+            return
+        }
+        XCTAssertEqual(value, 0.0)
+    }
+
+    // MARK: - Non-NSNumber
+
+    func testClassifyStringReturnsNil() {
+        XCTAssertNil(NSNumberClassifier.classify("hello"))
+    }
+
+    func testClassifyArrayReturnsNil() {
+        XCTAssertNil(NSNumberClassifier.classify([1, 2, 3]))
+    }
+
+    func testClassifyDictReturnsNil() {
+        XCTAssertNil(NSNumberClassifier.classify(["a": 1]))
+    }
+
+    func testClassifyNSNullReturnsNil() {
+        XCTAssertNil(NSNumberClassifier.classify(NSNull()))
+    }
+
+    // MARK: - Bool vs Int discrimination (가장 중요한 엣지 케이스)
+
+    func testBoolNotMisclassifiedAsInt() {
+        // NSNumber 1 == true에 대해 .bool로 분류돼야 함
+        let yesAsAny: Any = NSNumber(value: true)
+        let noAsAny: Any = NSNumber(value: false)
+        if case .int = NSNumberClassifier.classify(yesAsAny) {
+            XCTFail("true must not be classified as int")
+        }
+        if case .int = NSNumberClassifier.classify(noAsAny) {
+            XCTFail("false must not be classified as int")
+        }
+    }
+
+    func testIntNotMisclassifiedAsBool() {
+        if case .bool = NSNumberClassifier.classify(1) {
+            XCTFail("1 (Int literal) must not be classified as bool")
+        }
+        if case .bool = NSNumberClassifier.classify(0) {
+            XCTFail("0 (Int literal) must not be classified as bool")
+        }
+    }
+}

--- a/Tests/BluxClientTests/NotificationReceivedEventTests.swift
+++ b/Tests/BluxClientTests/NotificationReceivedEventTests.swift
@@ -1,0 +1,52 @@
+import XCTest
+import UIKit
+import UserNotifications
+@testable import BluxClient
+
+final class NotificationReceivedEventTests: XCTestCase {
+    func testInitAssignsNotification() {
+        let notif = BluxNotification(id: "n", body: "B", title: nil, url: nil, imageUrl: nil, data: nil)
+        let event = NotificationReceivedEvent(UIApplication.shared, notification: notif) { _ in }
+        XCTAssertEqual(event.notification.id, "n")
+    }
+
+    func testToDictionaryWrapsNotification() {
+        let notif = BluxNotification(id: "n", body: "B", title: "T", url: nil, imageUrl: nil, data: nil)
+        let event = NotificationReceivedEvent(UIApplication.shared, notification: notif) { _ in }
+        let dict = event.toDictionary()
+        XCTAssertNotNil(dict["notification"])
+        let inner = dict["notification"] as? [String: Any]
+        XCTAssertEqual(inner?["id"] as? String, "n")
+    }
+
+    // display()는 completion만 호출하고 EventService 등 외부 호출 없음. (회귀: created `received` event was duplicated)
+    func testDisplayInvokesCompletionWithDefaultPresentationOptionsOnce() {
+        var captured: UNNotificationPresentationOptions?
+        let exp = expectation(description: "completion called exactly once")
+        exp.expectedFulfillmentCount = 1
+        exp.assertForOverFulfill = true
+
+        let notif = BluxNotification(id: "x", body: "B", title: nil, url: nil, imageUrl: nil, data: nil)
+        let event = NotificationReceivedEvent(UIApplication.shared, notification: notif) { options in
+            captured = options
+            exp.fulfill()
+        }
+
+        event.display()
+
+        wait(for: [exp], timeout: 2.0)
+        XCTAssertEqual(captured, [.alert, .sound])
+    }
+
+    func testDisplayDoesNotRequireClientId() {
+        let savedClientId = SdkConfig.clientIdInUserDefaults
+        defer { SdkConfig.clientIdInUserDefaults = savedClientId }
+        SdkConfig.clientIdInUserDefaults = nil
+
+        let exp = expectation(description: "no crash")
+        let notif = BluxNotification(id: "x", body: "B", title: nil, url: nil, imageUrl: nil, data: nil)
+        let event = NotificationReceivedEvent(UIApplication.shared, notification: notif) { _ in exp.fulfill() }
+        event.display()
+        wait(for: [exp], timeout: 2.0)
+    }
+}

--- a/Tests/BluxClientTests/NotificationUrlOpenOptionsTests.swift
+++ b/Tests/BluxClientTests/NotificationUrlOpenOptionsTests.swift
@@ -1,0 +1,34 @@
+import XCTest
+@testable import BluxClient
+
+final class NotificationUrlOpenOptionsTests: XCTestCase {
+    func testDefaultIsInternalWebView() {
+        let options = NotificationUrlOpenOptions()
+        XCTAssertEqual(options.httpUrlOpenTarget, .internalWebView)
+    }
+
+    func testInitWithExternalBrowser() {
+        let options = NotificationUrlOpenOptions(httpUrlOpenTarget: .externalBrowser)
+        XCTAssertEqual(options.httpUrlOpenTarget, .externalBrowser)
+    }
+
+    func testInitWithNone() {
+        let options = NotificationUrlOpenOptions(httpUrlOpenTarget: .none)
+        XCTAssertEqual(options.httpUrlOpenTarget, .none)
+    }
+
+    func testHttpUrlOpenTargetRawValues() {
+        XCTAssertEqual(HttpUrlOpenTarget.internalWebView.rawValue, 0)
+        XCTAssertEqual(HttpUrlOpenTarget.externalBrowser.rawValue, 1)
+        XCTAssertEqual(HttpUrlOpenTarget.none.rawValue, 2)
+    }
+
+    func testHttpUrlOpenTargetRawInit() {
+        // .none이 Optional<HttpUrlOpenTarget>.none과 충돌하므로 rawValue로 비교
+        XCTAssertEqual(HttpUrlOpenTarget(rawValue: 0)?.rawValue, HttpUrlOpenTarget.internalWebView.rawValue)
+        XCTAssertEqual(HttpUrlOpenTarget(rawValue: 1)?.rawValue, HttpUrlOpenTarget.externalBrowser.rawValue)
+        XCTAssertEqual(HttpUrlOpenTarget(rawValue: 2)?.rawValue, HttpUrlOpenTarget.none.rawValue)
+        XCTAssertNil(HttpUrlOpenTarget(rawValue: 99))
+        XCTAssertNil(HttpUrlOpenTarget(rawValue: -1))
+    }
+}

--- a/Tests/BluxClientTests/RNFlutterBridgeContractTests.swift
+++ b/Tests/BluxClientTests/RNFlutterBridgeContractTests.swift
@@ -1,0 +1,297 @@
+import XCTest
+import UIKit
+@testable import BluxClient
+
+/// React Native/Flutter SDK는 iOS SDK의 public API에 직접 의존한다.
+/// 이 테스트는 두 SDK가 사용하는 패턴이 깨지지 않음을 검증한다.
+///
+/// **RN(`Blux-RN-SDK/ios/Blux.swift`)이 호출하는 패턴**:
+/// - `BluxClient.setUserPropertiesData(userProperties: [String: Any])` (snake_case dict)
+/// - `Event(eventType:)` + `capturedAt = ...` + `setEventProperties(EventProperties)` + `setCustomEventProperties` + `setInternalEventProperties`
+/// - `BluxClient.sendRequestData([Event])`
+/// - `BluxClient.addInAppCustomActionHandler { actionId, data in ... }` (returns unsubscribe)
+///
+/// **Flutter(`Blux-Flutter-SDK/ios/Classes/BluxFlutterPlugin.swift`)가 호출하는 패턴**:
+/// - `UserProperties(phoneNumber:..., gender:...)` 모든 옵셔널 init
+/// - `UserProperties.Gender(rawValue:)` ("male"/"female")
+/// - `HttpUrlOpenTarget` 멤버 (`.internalWebView`, `.externalBrowser`, `.none`)
+/// - `NotificationReceivedEvent.toDictionary()` / `display()`
+/// - `BluxNotification.toDictionary()`
+final class RNFlutterBridgeContractTests: XCTestCase {
+    private var guardian: SdkStateGuard!
+
+    override func setUp() {
+        super.setUp()
+        guardian = SdkStateGuard()
+        guardian.clear()
+    }
+
+    override func tearDown() {
+        guardian.restore()
+        guardian = nil
+        super.tearDown()
+    }
+
+    // MARK: - RN: setUserPropertiesData with [String: Any]
+
+    func testRN_SetUserPropertiesDataAcceptsArbitraryDict() {
+        // RN은 JS의 객체를 [String: Any]로 변환해 넘김
+        let dict: [String: Any?] = [
+            "phone_number": "010",
+            "email_address": "x@y",
+            "marketing_notification_consent": true,
+            "age": 30,
+            "gender": "female"
+        ]
+        // SdkConfig IDs 없으면 early return. 크래시 안 나는지만 검증.
+        BluxClient.setUserPropertiesData(userProperties: dict)
+    }
+
+    func testRN_SetUserPropertiesDataHandlesNilValues() {
+        let dict: [String: Any?] = [
+            "phone_number": nil,
+            "email_address": "x@y"
+        ]
+        BluxClient.setUserPropertiesData(userProperties: dict)
+    }
+
+    func testRN_SetCustomUserPropertiesAcceptsAnyValue() {
+        let dict: [String: Any?] = [
+            "score": 100,
+            "tier": "gold",
+            "active": true,
+            "tags": ["a", "b"],
+            "removed": nil
+        ]
+        BluxClient.setCustomUserProperties(customUserProperties: dict)
+    }
+
+    // MARK: - RN: Event from NSDictionary (sendRequest 패턴 재현)
+
+    func testRN_EventFromDictionaryWithSnakeCaseProperties() throws {
+        // RN의 sendRequest 핸들러가 만드는 Event를 직접 재현
+        let dict: [String: Any] = [
+            "event_type": "page_view",
+            "captured_at": "2025-04-26T12:34:56.789Z",
+            "event_properties": [
+                "page": "home",
+                "prev_page": "splash",
+                "section": "hero"
+            ],
+            "custom_event_properties": [
+                "scroll_depth": 0.5,
+                "ab_variant": "B"
+            ],
+            "internal_event_properties": [
+                "url": "/home",
+                "ref": "/splash"
+            ]
+        ]
+
+        guard let eventType = dict["event_type"] as? String,
+              let capturedAt = dict["captured_at"] as? String,
+              let propsDict = dict["event_properties"] as? [String: Any],
+              let customDict = dict["custom_event_properties"] as? [String: Any],
+              let internalDict = dict["internal_event_properties"] as? [String: Any]
+        else {
+            XCTFail("Test fixture is malformed")
+            return
+        }
+
+        let event = Event(eventType: eventType)
+        event.capturedAt = capturedAt
+
+        let propsData = try JSONSerialization.data(withJSONObject: propsDict)
+        let props = try JSONDecoder().decode(EventProperties.self, from: propsData)
+        event.setEventProperties(props)
+
+        var custom: [String: CustomEventValue] = [:]
+        for (k, v) in customDict {
+            if let converted = CustomEventValue.fromAny(v) {
+                custom[k] = converted
+            }
+        }
+        event.setCustomEventProperties(custom)
+
+        var int: [String: CustomEventValue] = [:]
+        for (k, v) in internalDict {
+            if let converted = CustomEventValue.fromAny(v) {
+                int[k] = converted
+            }
+        }
+        event.setInternalEventProperties(int)
+
+        // 결과 검증
+        XCTAssertEqual(event.eventType, "page_view")
+        XCTAssertEqual(event.capturedAt, "2025-04-26T12:34:56.789Z")
+        XCTAssertEqual(event.eventProperties.page, "home")
+        XCTAssertEqual(event.eventProperties.prevSection, nil)
+        XCTAssertEqual(event.eventProperties.section, "hero")
+        if case .double(let d)? = event.customEventProperties?["scroll_depth"] {
+            XCTAssertEqual(d, 0.5, accuracy: 0.001)
+        } else { XCTFail() }
+        if case .string("B")? = event.customEventProperties?["ab_variant"] {} else { XCTFail() }
+        if case .string("/home")? = event.internalEventProperties?["url"] {} else { XCTFail() }
+    }
+
+    func testRN_SendRequestDataWithEventArrayDoesNotCrash() {
+        let event = Event(eventType: "x")
+        BluxClient.sendRequestData([event])
+    }
+
+    func testRN_AddInAppCustomActionHandlerReturnsUnsubscribe() {
+        // RN의 startInAppCustomActionHandler는 unsubscribe 클로저를 저장한다.
+        let savedCount = EventHandlers.inAppCustomActionHandlers.count
+        let unsubscribe: () -> Void = BluxClient.addInAppCustomActionHandler { _, _ in }
+        XCTAssertEqual(EventHandlers.inAppCustomActionHandlers.count, savedCount + 1)
+        unsubscribe()
+        XCTAssertEqual(EventHandlers.inAppCustomActionHandlers.count, savedCount)
+    }
+
+    // MARK: - Flutter: UserProperties 직접 init (모두 옵셔널)
+
+    func testFlutter_UserPropertiesAllOptionalInit() {
+        // Flutter plugin은 dict에서 각 필드를 추출해 직접 init
+        let properties = UserProperties(
+            phoneNumber: nil,
+            emailAddress: nil,
+            marketingNotificationConsent: nil,
+            marketingNotificationSmsConsent: nil,
+            marketingNotificationEmailConsent: nil,
+            marketingNotificationPushConsent: nil,
+            marketingNotificationKakaoConsent: nil,
+            nighttimeNotificationConsent: nil,
+            isAllNotificationBlocked: nil,
+            age: nil,
+            gender: nil
+        )
+        BluxClient.setUserProperties(userProperties: properties)
+        // 모든 필드 nil이어도 호출 가능
+    }
+
+    func testFlutter_UserPropertiesPartialInit() {
+        let properties = UserProperties(
+            phoneNumber: "010-1234",
+            age: 33
+        )
+        XCTAssertEqual(properties.phoneNumber, "010-1234")
+        XCTAssertEqual(properties.age, 33)
+        XCTAssertNil(properties.emailAddress)
+        XCTAssertNil(properties.gender)
+    }
+
+    func testFlutter_UserPropertiesGenderRawValueRoundTrip() {
+        // Flutter: UserProperties.Gender(rawValue: "female")로 매핑
+        XCTAssertEqual(UserProperties.Gender(rawValue: "male"), .male)
+        XCTAssertEqual(UserProperties.Gender(rawValue: "female"), .female)
+        XCTAssertNil(UserProperties.Gender(rawValue: "other"))
+        XCTAssertNil(UserProperties.Gender(rawValue: "MALE"))  // case-sensitive
+        XCTAssertNil(UserProperties.Gender(rawValue: ""))
+    }
+
+    // MARK: - Flutter: HttpUrlOpenTarget 문자열 매핑
+
+    func testFlutter_HttpUrlOpenTargetMembersAccessible() {
+        // Flutter plugin이 사용하는 case들이 public으로 노출되어야 함
+        let internalCase: HttpUrlOpenTarget = .internalWebView
+        let externalCase: HttpUrlOpenTarget = .externalBrowser
+        let noneCase: HttpUrlOpenTarget = HttpUrlOpenTarget.none
+
+        XCTAssertEqual(internalCase.rawValue, 0)
+        XCTAssertEqual(externalCase.rawValue, 1)
+        XCTAssertEqual(noneCase.rawValue, 2)
+    }
+
+    func testFlutter_NotificationUrlOpenOptionsInitWithAllTargets() {
+        // 각 target에 대해 init 가능
+        let opts1 = NotificationUrlOpenOptions(httpUrlOpenTarget: .internalWebView)
+        let opts2 = NotificationUrlOpenOptions(httpUrlOpenTarget: .externalBrowser)
+        let opts3 = NotificationUrlOpenOptions(httpUrlOpenTarget: HttpUrlOpenTarget.none)
+
+        BluxClient.setNotificationUrlOpenOptions(opts1)
+        XCTAssertEqual(SdkConfig.notificationUrlOpenOptions.httpUrlOpenTarget, .internalWebView)
+        BluxClient.setNotificationUrlOpenOptions(opts2)
+        XCTAssertEqual(SdkConfig.notificationUrlOpenOptions.httpUrlOpenTarget, .externalBrowser)
+        BluxClient.setNotificationUrlOpenOptions(opts3)
+        XCTAssertEqual(SdkConfig.notificationUrlOpenOptions.httpUrlOpenTarget, HttpUrlOpenTarget.none)
+    }
+
+    // MARK: - Flutter: Event chain (BluxFlutterPlugin sendEvent 패턴)
+
+    func testFlutter_EventChainWithSetEventProperties() throws {
+        let dict: [String: Any] = [
+            "event_type": "purchase",
+            "event_properties": [
+                "order_id": "O-1",
+                "order_amount": 100.0,
+                "paid_amount": 90.0
+            ]
+        ]
+
+        let eventType = dict["event_type"] as! String
+        let propsDict = dict["event_properties"] as! [String: Any]
+        let propsData = try JSONSerialization.data(withJSONObject: propsDict)
+        let props = try JSONDecoder().decode(EventProperties.self, from: propsData)
+
+        let event = Event(eventType: eventType)
+            .setEventProperties(props)
+            .setCustomEventProperties(nil)
+            .setInternalEventProperties(nil)
+
+        XCTAssertEqual(event.eventType, "purchase")
+        XCTAssertEqual(event.eventProperties.orderId, "O-1")
+        XCTAssertEqual(event.eventProperties.orderAmount, 100)
+        XCTAssertEqual(event.eventProperties.paidAmount, 90)
+    }
+
+    func testFlutter_EventPropertiesDecodeFromEmptyDict() throws {
+        // sendEvent 처리에서 event_properties가 비어있어도 정상 디코딩
+        let data = try JSONSerialization.data(withJSONObject: [String: Any]())
+        let props = try JSONDecoder().decode(EventProperties.self, from: data)
+        XCTAssertNil(props.itemId)
+        XCTAssertNil(props.page)
+    }
+
+    // MARK: - Flutter: Notification handler / display 패턴
+
+    func testFlutter_BluxNotificationToDictionaryRoundTrip() {
+        // Flutter는 BluxNotification.toDictionary()를 channel arguments로 보냄
+        let notif = BluxNotification(
+            id: "n",
+            body: "B",
+            title: "T",
+            url: "U",
+            imageUrl: "I",
+            data: ["k": "v"]
+        )
+        let dict = notif.toDictionary()
+        XCTAssertEqual(dict["id"] as? String, "n")
+        XCTAssertEqual(dict["body"] as? String, "B")
+        XCTAssertEqual(dict["title"] as? String, "T")
+        XCTAssertEqual(dict["url"] as? String, "U")
+        XCTAssertEqual(dict["imageUrl"] as? String, "I")
+        let inner = dict["data"] as? [String: Any]
+        XCTAssertEqual(inner?["k"] as? String, "v")
+    }
+
+    func testFlutter_BluxNotificationToDictionaryWithNils() {
+        // Flutter side가 nil을 받아도 깨지지 않아야 함
+        let notif = BluxNotification(
+            id: "n",
+            body: "B",
+            title: nil,
+            url: nil,
+            imageUrl: nil,
+            data: nil
+        )
+        let dict = notif.toDictionary()
+        XCTAssertEqual(dict["id"] as? String, "n")
+        XCTAssertNotNil(dict.keys.contains("title"))
+        // Optional<String>의 nil이 dict[Key]: Any?로 들어감 → 키는 존재하나 unwrap하면 nil
+    }
+
+    // public API surface 시그니처/타입 컴파일 검증과 StageSwitcher ObjC 노출 검증은
+    // BluxClientPublicAPITests testTarget으로 이동 (plain `import BluxClient`로 wrapper SDK와
+    // 동일한 access modifier 환경에서 검증). 이 파일은 @testable import라 internal까지
+    // 보여 access-control 강등 회귀를 잡지 못한다.
+}

--- a/Tests/BluxClientTests/SdkConfigTests.swift
+++ b/Tests/BluxClientTests/SdkConfigTests.swift
@@ -1,0 +1,139 @@
+import XCTest
+@testable import BluxClient
+
+final class SdkConfigTests: XCTestCase {
+    private var guardian: SdkStateGuard!
+    private var savedNotificationUrlOpenOptions: NotificationUrlOpenOptions!
+    // SdkConfig 내부 private key와 동기화 필요 (default 동작 검증을 위해 키 자체를 제거)
+    private let notificationUrlOpenOptionsUserDefaultsKey = "bluxNotificationUrlOpenOptions"
+
+    override func setUp() {
+        super.setUp()
+        guardian = SdkStateGuard()
+        guardian.clear()
+        savedNotificationUrlOpenOptions = SdkConfig.notificationUrlOpenOptions
+        UserDefaults(suiteName: SdkConfig.bluxSuiteName)?
+            .removeObject(forKey: notificationUrlOpenOptionsUserDefaultsKey)
+    }
+
+    override func tearDown() {
+        SdkConfig.notificationUrlOpenOptions = savedNotificationUrlOpenOptions
+        guardian.restore()
+        guardian = nil
+        super.tearDown()
+    }
+
+    // MARK: - Header constants
+
+    func testHeaderConstantsAreStable() {
+        // 서버 contract와 직결되므로 이름이 바뀌면 SDK 통신 깨짐
+        XCTAssertEqual(SdkConfig.bluxSdkInfoHeader, "X-BLUX-SDK-INFO")
+        XCTAssertEqual(SdkConfig.bluxClientIdHeader, "X-BLUX-CLIENT-ID")
+        XCTAssertEqual(SdkConfig.bluxAuthorizationHeader, "Authorization")
+        XCTAssertEqual(SdkConfig.bluxApiKeyHeader, "X-BLUX-API-KEY")
+        XCTAssertEqual(SdkConfig.bluxUnixTimestampHeader, "X-BLUX-TIMESTAMP")
+    }
+
+    // MARK: - Default values
+
+    func testDefaultLogLevelIsVerbose() {
+        // 기본 logLevel은 verbose - 변경 시 사이드이펙트 큼
+        let saved = SdkConfig.logLevel
+        defer { SdkConfig.logLevel = saved }
+        // 새 SdkConfig 인스턴스를 만들 수 없으니 enum 자체 확인
+        XCTAssertEqual(LogLevel.verbose.rawValue, 5)
+    }
+
+    func testSdkTypeDefaultIsNative() {
+        // 기본 sdkType은 native (RN/Flutter wrapper에서 변경)
+        XCTAssertEqual(SdkConfig.sdkType, .native)
+    }
+
+    func testSdkTypeRawValues() {
+        XCTAssertEqual(SdkType.native.rawValue, "native")
+        XCTAssertEqual(SdkType.reactnative.rawValue, "reactnative")
+        XCTAssertEqual(SdkType.flutter.rawValue, "flutter")
+    }
+
+    // MARK: - UserDefaults persistence
+
+    func testClientIdPersistence() {
+        XCTAssertNil(SdkConfig.clientIdInUserDefaults)
+        SdkConfig.clientIdInUserDefaults = "client-123"
+        XCTAssertEqual(SdkConfig.clientIdInUserDefaults, "client-123")
+        SdkConfig.clientIdInUserDefaults = nil
+        XCTAssertNil(SdkConfig.clientIdInUserDefaults)
+    }
+
+    func testApiKeyPersistence() {
+        SdkConfig.apiKeyInUserDefaults = "api-key-xyz"
+        XCTAssertEqual(SdkConfig.apiKeyInUserDefaults, "api-key-xyz")
+    }
+
+    func testBluxIdPersistence() {
+        SdkConfig.bluxIdInUserDefaults = "blux-abc"
+        XCTAssertEqual(SdkConfig.bluxIdInUserDefaults, "blux-abc")
+    }
+
+    func testDeviceIdPersistence() {
+        SdkConfig.deviceIdInUserDefaults = "device-001"
+        XCTAssertEqual(SdkConfig.deviceIdInUserDefaults, "device-001")
+    }
+
+    func testUserIdPersistence() {
+        SdkConfig.userIdInUserDefaults = "user-007"
+        XCTAssertEqual(SdkConfig.userIdInUserDefaults, "user-007")
+        SdkConfig.userIdInUserDefaults = nil
+        XCTAssertNil(SdkConfig.userIdInUserDefaults)
+    }
+
+    func testEachKeyIsIndependent() {
+        SdkConfig.clientIdInUserDefaults = "C"
+        SdkConfig.apiKeyInUserDefaults = "K"
+        SdkConfig.bluxIdInUserDefaults = "B"
+        SdkConfig.deviceIdInUserDefaults = "D"
+        SdkConfig.userIdInUserDefaults = "U"
+
+        XCTAssertEqual(SdkConfig.clientIdInUserDefaults, "C")
+        XCTAssertEqual(SdkConfig.apiKeyInUserDefaults, "K")
+        XCTAssertEqual(SdkConfig.bluxIdInUserDefaults, "B")
+        XCTAssertEqual(SdkConfig.deviceIdInUserDefaults, "D")
+        XCTAssertEqual(SdkConfig.userIdInUserDefaults, "U")
+    }
+
+    // MARK: - Session ID
+
+    func testSessionIdAutoGeneratesUUID() {
+        let sid = SdkConfig.sessionId
+        XCTAssertFalse(sid.isEmpty)
+        XCTAssertNotNil(UUID(uuidString: sid), "Default sessionId should be a valid UUID")
+    }
+
+    func testSessionIdIsStableAcrossReads() {
+        let first = SdkConfig.sessionId
+        let second = SdkConfig.sessionId
+        XCTAssertEqual(first, second)
+    }
+
+    func testSessionIdSetterOverrides() {
+        SdkConfig.sessionId = "custom-session"
+        XCTAssertEqual(SdkConfig.sessionId, "custom-session")
+    }
+
+    // MARK: - NotificationUrlOpenOptions persistence
+
+    func testNotificationUrlOpenOptionsDefaultIsInternalWebView() {
+        let options = SdkConfig.notificationUrlOpenOptions
+        XCTAssertEqual(options.httpUrlOpenTarget, .internalWebView)
+    }
+
+    func testNotificationUrlOpenOptionsRoundTripExternalBrowser() {
+        SdkConfig.notificationUrlOpenOptions = NotificationUrlOpenOptions(httpUrlOpenTarget: .externalBrowser)
+        XCTAssertEqual(SdkConfig.notificationUrlOpenOptions.httpUrlOpenTarget, .externalBrowser)
+    }
+
+    func testNotificationUrlOpenOptionsRoundTripNone() {
+        SdkConfig.notificationUrlOpenOptions = NotificationUrlOpenOptions(httpUrlOpenTarget: .none)
+        XCTAssertEqual(SdkConfig.notificationUrlOpenOptions.httpUrlOpenTarget, .none)
+    }
+}

--- a/Tests/BluxClientTests/SdkConfigTests.swift
+++ b/Tests/BluxClientTests/SdkConfigTests.swift
@@ -136,4 +136,18 @@ final class SdkConfigTests: XCTestCase {
         SdkConfig.notificationUrlOpenOptions = NotificationUrlOpenOptions(httpUrlOpenTarget: .none)
         XCTAssertEqual(SdkConfig.notificationUrlOpenOptions.httpUrlOpenTarget, .none)
     }
+
+    // 메모리에만 저장하면 콜드 스타트 시 default(.internalWebView)로 리셋된다.
+    // UserDefaults에 영속화되어 여러 read에서 보존되어야 한다.
+    func testNotificationUrlOpenOptionsPersistsAcrossReads() {
+        SdkConfig.notificationUrlOpenOptions = NotificationUrlOpenOptions(httpUrlOpenTarget: .externalBrowser)
+        for _ in 0..<3 {
+            XCTAssertEqual(SdkConfig.notificationUrlOpenOptions.httpUrlOpenTarget, .externalBrowser)
+        }
+    }
+
+    func testNotificationUrlOpenOptionsPersistsNoneTarget() {
+        SdkConfig.notificationUrlOpenOptions = NotificationUrlOpenOptions(httpUrlOpenTarget: HttpUrlOpenTarget.none)
+        XCTAssertEqual(SdkConfig.notificationUrlOpenOptions.httpUrlOpenTarget, HttpUrlOpenTarget.none)
+    }
 }

--- a/Tests/BluxClientTests/StageTests.swift
+++ b/Tests/BluxClientTests/StageTests.swift
@@ -1,0 +1,84 @@
+import XCTest
+@testable import BluxClient
+
+final class StageTests: XCTestCase {
+    func testFromKnownLowercase() {
+        XCTAssertEqual(Stage.from("local"), .local)
+        XCTAssertEqual(Stage.from("dev"), .dev)
+        XCTAssertEqual(Stage.from("stg"), .stg)
+        XCTAssertEqual(Stage.from("prod"), .prod)
+    }
+
+    func testFromKnownUppercase() {
+        XCTAssertEqual(Stage.from("LOCAL"), .local)
+        XCTAssertEqual(Stage.from("DEV"), .dev)
+        XCTAssertEqual(Stage.from("STG"), .stg)
+        XCTAssertEqual(Stage.from("PROD"), .prod)
+    }
+
+    func testFromMixedCase() {
+        XCTAssertEqual(Stage.from("Dev"), .dev)
+        XCTAssertEqual(Stage.from("dEv"), .dev)
+    }
+
+    func testFromNilFallsBackToProd() {
+        XCTAssertEqual(Stage.from(nil), .prod)
+    }
+
+    func testFromEmptyStringFallsBackToProd() {
+        XCTAssertEqual(Stage.from(""), .prod)
+    }
+
+    func testFromUnknownValueFallsBackToProd() {
+        XCTAssertEqual(Stage.from("staging"), .prod)
+        XCTAssertEqual(Stage.from("production"), .prod)
+        XCTAssertEqual(Stage.from("nonsense"), .prod)
+    }
+
+    func testApiBaseURL() {
+        XCTAssertEqual(Stage.local.apiBaseURL, .local)
+        XCTAssertEqual(Stage.dev.apiBaseURL, .dev)
+        XCTAssertEqual(Stage.stg.apiBaseURL, .stg)
+        XCTAssertEqual(Stage.prod.apiBaseURL, .prod)
+    }
+
+    func testAPIBaseURLValues() {
+        XCTAssertEqual(HTTPClient.APIBaseURLByStage.local.rawValue, "http://localhost:3003/red/red")
+        XCTAssertEqual(HTTPClient.APIBaseURLByStage.dev.rawValue, "https://api.blux.ai/dev")
+        XCTAssertEqual(HTTPClient.APIBaseURLByStage.stg.rawValue, "https://api.blux.ai/stg")
+        XCTAssertEqual(HTTPClient.APIBaseURLByStage.prod.rawValue, "https://api.blux.ai/prod")
+    }
+
+    func testAllCasesContainsAllStages() {
+        XCTAssertEqual(Set(Stage.allCases), Set([.local, .dev, .stg, .prod]))
+    }
+
+    // MARK: - setStage / resetStage
+
+    /// 빌드 시점 기본 스테이지가 prod이 아닐 때만 setStage가 동작.
+    /// 테스트 환경에서는 BLUX_LOCAL/DEV/STG flag가 없으므로 default는 prod.
+    /// 따라서 setStage는 false를 반환하고 current는 prod 유지.
+    func testSetStageReturnsFalseWhenDefaultIsProd() {
+        let result = Stage.setStage(.dev)
+        XCTAssertFalse(result, "Default stage in test build is prod, so setStage should be no-op")
+        XCTAssertEqual(Stage.current, .prod)
+    }
+
+    func testResetStageIsNoOpWhenDefaultIsProd() {
+        // resetStage는 단순히 prod default일 때 early return; 크래시 없으면 통과
+        Stage.resetStage()
+        XCTAssertEqual(Stage.current, .prod)
+    }
+
+    func testStageSwitcherForwardsToStage() {
+        StageSwitcher.setStage("dev")
+        // default가 prod라 변경되지 않아야 함
+        XCTAssertEqual(Stage.current, .prod)
+
+        StageSwitcher.setStage("invalid-value")
+        XCTAssertEqual(Stage.current, .prod)
+
+        StageSwitcher.resetStage()
+        XCTAssertEqual(Stage.current, .prod)
+    }
+}

--- a/Tests/BluxClientTests/UIColorHexTests.swift
+++ b/Tests/BluxClientTests/UIColorHexTests.swift
@@ -1,0 +1,96 @@
+import XCTest
+import UIKit
+@testable import BluxClient
+
+final class UIColorHexTests: XCTestCase {
+    private func components(of color: UIColor) -> (CGFloat, CGFloat, CGFloat, CGFloat) {
+        var r: CGFloat = -1, g: CGFloat = -1, b: CGFloat = -1, a: CGFloat = -1
+        color.getRed(&r, green: &g, blue: &b, alpha: &a)
+        return (r, g, b, a)
+    }
+
+    func testHexWithLeadingHash() {
+        let color = UIColor(hex: "#FF0000")
+        let (r, g, b, a) = components(of: color)
+        XCTAssertEqual(r, 1.0, accuracy: 0.001)
+        XCTAssertEqual(g, 0.0, accuracy: 0.001)
+        XCTAssertEqual(b, 0.0, accuracy: 0.001)
+        XCTAssertEqual(a, 1.0, accuracy: 0.001)
+    }
+
+    func testHexWithoutLeadingHash() {
+        let color = UIColor(hex: "00FF00")
+        let (r, g, b, a) = components(of: color)
+        XCTAssertEqual(r, 0.0, accuracy: 0.001)
+        XCTAssertEqual(g, 1.0, accuracy: 0.001)
+        XCTAssertEqual(b, 0.0, accuracy: 0.001)
+        XCTAssertEqual(a, 1.0, accuracy: 0.001)
+    }
+
+    func testHexBlueChannel() {
+        let color = UIColor(hex: "0000FF")
+        let (r, g, b, _) = components(of: color)
+        XCTAssertEqual(r, 0.0, accuracy: 0.001)
+        XCTAssertEqual(g, 0.0, accuracy: 0.001)
+        XCTAssertEqual(b, 1.0, accuracy: 0.001)
+    }
+
+    func testHexBlack() {
+        let color = UIColor(hex: "#000000")
+        let (r, g, b, _) = components(of: color)
+        XCTAssertEqual(r, 0.0, accuracy: 0.001)
+        XCTAssertEqual(g, 0.0, accuracy: 0.001)
+        XCTAssertEqual(b, 0.0, accuracy: 0.001)
+    }
+
+    func testHexWhite() {
+        let color = UIColor(hex: "#FFFFFF")
+        let (r, g, b, _) = components(of: color)
+        XCTAssertEqual(r, 1.0, accuracy: 0.001)
+        XCTAssertEqual(g, 1.0, accuracy: 0.001)
+        XCTAssertEqual(b, 1.0, accuracy: 0.001)
+    }
+
+    func testHexLowercase() {
+        let lower = UIColor(hex: "abcdef")
+        let upper = UIColor(hex: "ABCDEF")
+        let lc = components(of: lower)
+        let uc = components(of: upper)
+        XCTAssertEqual(lc.0, uc.0, accuracy: 0.001)
+        XCTAssertEqual(lc.1, uc.1, accuracy: 0.001)
+        XCTAssertEqual(lc.2, uc.2, accuracy: 0.001)
+    }
+
+    func testHexWithWhitespace() {
+        let color = UIColor(hex: "  #FF8800  ")
+        let (r, g, b, _) = components(of: color)
+        XCTAssertEqual(r, 1.0, accuracy: 0.001)
+        XCTAssertEqual(g, 136.0/255.0, accuracy: 0.001)
+        XCTAssertEqual(b, 0.0, accuracy: 0.001)
+    }
+
+    func testInvalidHexFallsBackToBlack() {
+        // Scanner가 hex로 파싱 실패하면 rgb=0이 되어 검정색이 됨
+        let color = UIColor(hex: "ZZZZZZ")
+        let (r, g, b, a) = components(of: color)
+        XCTAssertEqual(r, 0.0, accuracy: 0.001)
+        XCTAssertEqual(g, 0.0, accuracy: 0.001)
+        XCTAssertEqual(b, 0.0, accuracy: 0.001)
+        XCTAssertEqual(a, 1.0, accuracy: 0.001)
+    }
+
+    func testEmptyHexFallsBackToBlack() {
+        let color = UIColor(hex: "")
+        let (r, g, b, a) = components(of: color)
+        XCTAssertEqual(r, 0.0, accuracy: 0.001)
+        XCTAssertEqual(g, 0.0, accuracy: 0.001)
+        XCTAssertEqual(b, 0.0, accuracy: 0.001)
+        XCTAssertEqual(a, 1.0, accuracy: 0.001)
+    }
+
+    func testAlphaIsAlwaysOne() {
+        let color = UIColor(hex: "#123456")
+        let (_, _, _, a) = components(of: color)
+        XCTAssertEqual(a, 1.0, accuracy: 0.001)
+    }
+}

--- a/Tests/BluxClientTests/UserPropertiesTests.swift
+++ b/Tests/BluxClientTests/UserPropertiesTests.swift
@@ -1,0 +1,105 @@
+import XCTest
+@testable import BluxClient
+
+/// 서버 `/update-properties` body의 user_properties 객체와 매칭.
+/// 모든 필드는 선택. snake_case 키 변환 정확성 검증.
+final class UserPropertiesTests: XCTestCase {
+    private let encoder = JSONEncoder()
+    private let decoder = JSONDecoder()
+
+    func testInitWithDefaultsHasAllNil() {
+        let props = UserProperties()
+        XCTAssertNil(props.phoneNumber)
+        XCTAssertNil(props.emailAddress)
+        XCTAssertNil(props.gender)
+        XCTAssertNil(props.age)
+    }
+
+    func testInitWithAllValues() {
+        let props = UserProperties(
+            phoneNumber: "010-1234-5678",
+            emailAddress: "test@blux.ai",
+            marketingNotificationConsent: true,
+            marketingNotificationSmsConsent: false,
+            marketingNotificationEmailConsent: true,
+            marketingNotificationPushConsent: false,
+            marketingNotificationKakaoConsent: true,
+            nighttimeNotificationConsent: false,
+            isAllNotificationBlocked: false,
+            age: 28,
+            gender: .female
+        )
+
+        XCTAssertEqual(props.phoneNumber, "010-1234-5678")
+        XCTAssertEqual(props.emailAddress, "test@blux.ai")
+        XCTAssertEqual(props.marketingNotificationConsent, true)
+        XCTAssertEqual(props.gender, .female)
+        XCTAssertEqual(props.age, 28)
+    }
+
+    func testEncodingUsesSnakeCaseKeys() throws {
+        let props = UserProperties(
+            phoneNumber: "010",
+            marketingNotificationConsent: true,
+            marketingNotificationSmsConsent: false,
+            marketingNotificationEmailConsent: true,
+            marketingNotificationPushConsent: false,
+            marketingNotificationKakaoConsent: true,
+            nighttimeNotificationConsent: false,
+            isAllNotificationBlocked: true,
+            age: 30,
+            gender: .male
+        )
+        let data = try encoder.encode(props)
+        let dict = try JSONSerialization.jsonObject(with: data) as! [String: Any]
+
+        XCTAssertEqual(dict["phone_number"] as? String, "010")
+        XCTAssertEqual(dict["marketing_notification_consent"] as? Bool, true)
+        XCTAssertEqual(dict["marketing_notification_sms_consent"] as? Bool, false)
+        XCTAssertEqual(dict["marketing_notification_email_consent"] as? Bool, true)
+        XCTAssertEqual(dict["marketing_notification_push_consent"] as? Bool, false)
+        XCTAssertEqual(dict["marketing_notification_kakao_consent"] as? Bool, true)
+        XCTAssertEqual(dict["nighttime_notification_consent"] as? Bool, false)
+        XCTAssertEqual(dict["is_all_notification_blocked"] as? Bool, true)
+        XCTAssertEqual(dict["age"] as? Int, 30)
+        XCTAssertEqual(dict["gender"] as? String, "male")
+    }
+
+    func testEncodingOmitsNilFields() throws {
+        let props = UserProperties(emailAddress: "only@blux.ai")
+        let data = try encoder.encode(props)
+        let dict = try JSONSerialization.jsonObject(with: data) as! [String: Any]
+        XCTAssertEqual(dict["email_address"] as? String, "only@blux.ai")
+        XCTAssertNil(dict["phone_number"])
+        XCTAssertNil(dict["age"])
+        XCTAssertNil(dict["gender"])
+    }
+
+    func testGenderRawValues() {
+        XCTAssertEqual(UserProperties.Gender.male.rawValue, "male")
+        XCTAssertEqual(UserProperties.Gender.female.rawValue, "female")
+    }
+
+    func testGenderRoundTrip() throws {
+        for gender in [UserProperties.Gender.male, .female] {
+            let data = try encoder.encode(["g": gender])
+            let decoded = try decoder.decode([String: UserProperties.Gender].self, from: data)
+            XCTAssertEqual(decoded["g"], gender)
+        }
+    }
+
+    func testRoundTripOfFullProperties() throws {
+        let original = UserProperties(
+            phoneNumber: "010",
+            emailAddress: "x@y",
+            age: 21,
+            gender: .female
+        )
+        let data = try encoder.encode(original)
+        let decoded = try decoder.decode(UserProperties.self, from: data)
+        XCTAssertEqual(decoded.phoneNumber, "010")
+        XCTAssertEqual(decoded.emailAddress, "x@y")
+        XCTAssertEqual(decoded.age, 21)
+        XCTAssertEqual(decoded.gender, .female)
+    }
+}

--- a/Tests/BluxClientTests/ValidatorTests.swift
+++ b/Tests/BluxClientTests/ValidatorTests.swift
@@ -1,0 +1,135 @@
+import XCTest
+@testable import BluxClient
+
+final class ValidatorTests: XCTestCase {
+    // MARK: - validateString (non-optional)
+
+    func testValidateString_ReturnsValueWhenWithinRange() throws {
+        let value = try Validator.validateString("hello", min: 1, max: 10, varName: "name")
+        XCTAssertEqual(value, "hello")
+    }
+
+    func testValidateString_ReturnsValueAtMinBoundary() throws {
+        let value = try Validator.validateString("a", min: 1, max: 10, varName: "name")
+        XCTAssertEqual(value, "a")
+    }
+
+    func testValidateString_ReturnsValueAtMaxBoundary() throws {
+        let value = try Validator.validateString("abcdefghij", min: 1, max: 10, varName: "name")
+        XCTAssertEqual(value.count, 10)
+    }
+
+    func testValidateString_ThrowsWhenShorterThanMin() {
+        XCTAssertThrowsError(try Validator.validateString("", min: 1, max: 10, varName: "name")) { error in
+            guard case let BluxError.LengthOutOfRangeBetween(name, _, _) = error else {
+                XCTFail("Expected LengthOutOfRangeBetween, got \(error)")
+                return
+            }
+            XCTAssertEqual(name, "name")
+        }
+    }
+
+    func testValidateString_ThrowsWhenLongerThanMax() {
+        XCTAssertThrowsError(try Validator.validateString("abcdefghijk", min: 1, max: 10, varName: "name")) { error in
+            guard case BluxError.LengthOutOfRangeBetween = error else {
+                XCTFail("Expected LengthOutOfRangeBetween, got \(error)")
+                return
+            }
+        }
+    }
+
+    func testValidateString_NoMaxOnlyChecksMin() throws {
+        let value = try Validator.validateString("very long string with no upper bound applied", min: 1, varName: "page")
+        XCTAssertFalse(value.isEmpty)
+    }
+
+    func testValidateString_NoMaxThrowsLengthOutOfRangeGeWhenShort() {
+        XCTAssertThrowsError(try Validator.validateString("", min: 5, varName: "page")) { error in
+            guard case BluxError.LengthOutOfRangeGe = error else {
+                XCTFail("Expected LengthOutOfRangeGe, got \(error)")
+                return
+            }
+        }
+    }
+
+    func testValidateString_HandlesUnicodeLength() throws {
+        // 한글 5글자 (Character count 기준)
+        let value = try Validator.validateString("안녕하세요", min: 5, max: 5, varName: "korean")
+        XCTAssertEqual(value, "안녕하세요")
+    }
+
+    func testValidateString_RejectsBytesBeyondCharCount() {
+        // emoji는 1글자로 카운트되어야 함
+        XCTAssertThrowsError(try Validator.validateString("🎉🎉🎉", min: 4, max: 100, varName: "emoji"))
+    }
+
+    // MARK: - validateString (optional)
+
+    func testValidateStringOptional_NilReturnsNil() throws {
+        let value = try Validator.validateString(nil, min: 1, max: 10, varName: "name")
+        XCTAssertNil(value)
+    }
+
+    func testValidateStringOptional_ValidValueReturnsValue() throws {
+        let value = try Validator.validateString(Optional("hello"), min: 1, max: 10, varName: "name")
+        XCTAssertEqual(value, "hello")
+    }
+
+    func testValidateStringOptional_ThrowsForOutOfRange() {
+        XCTAssertThrowsError(try Validator.validateString(Optional(""), min: 1, max: 10, varName: "name"))
+    }
+
+    // MARK: - validateNumber
+
+    func testValidateNumber_WithinRangeReturnsValue() throws {
+        let value = try Validator.validateNumber(5.0, min: 0.0, max: 10.0, varName: "price")
+        XCTAssertEqual(value, 5.0)
+    }
+
+    func testValidateNumber_AtMinBoundary() throws {
+        let value = try Validator.validateNumber(0.0, min: 0.0, max: 10.0, varName: "price")
+        XCTAssertEqual(value, 0.0)
+    }
+
+    func testValidateNumber_AtMaxBoundary() throws {
+        let value = try Validator.validateNumber(10.0, min: 0.0, max: 10.0, varName: "price")
+        XCTAssertEqual(value, 10.0)
+    }
+
+    func testValidateNumber_ThrowsWhenBelowMin() {
+        XCTAssertThrowsError(try Validator.validateNumber(-1.0, min: 0.0, max: 10.0, varName: "price")) { error in
+            guard case BluxError.ValueOutOfRangeBetween = error else {
+                XCTFail("Expected ValueOutOfRangeBetween, got \(error)")
+                return
+            }
+        }
+    }
+
+    func testValidateNumber_ThrowsWhenAboveMax() {
+        XCTAssertThrowsError(try Validator.validateNumber(11.0, min: 0.0, max: 10.0, varName: "price")) { error in
+            guard case BluxError.ValueOutOfRangeBetween = error else {
+                XCTFail("Expected ValueOutOfRangeBetween, got \(error)")
+                return
+            }
+        }
+    }
+
+    func testValidateNumber_NoMaxOnlyChecksMin() throws {
+        let value = try Validator.validateNumber(99999.99, min: 0.0, varName: "price")
+        XCTAssertEqual(value, 99999.99)
+    }
+
+    func testValidateNumber_NoMaxThrowsValueOutOfRangeGe() {
+        XCTAssertThrowsError(try Validator.validateNumber(-0.01, min: 0.0, varName: "price")) { error in
+            guard case BluxError.ValueOutOfRangeGe = error else {
+                XCTFail("Expected ValueOutOfRangeGe, got \(error)")
+                return
+            }
+        }
+    }
+
+    func testValidateNumber_GenericIntType() throws {
+        let value = try Validator.validateNumber(42, min: 0, max: 100, varName: "age")
+        XCTAssertEqual(value, 42)
+    }
+}

--- a/Tests/BluxClientTests/builders/AddCartaddEventTests.swift
+++ b/Tests/BluxClientTests/builders/AddCartaddEventTests.swift
@@ -1,0 +1,44 @@
+import XCTest
+@testable import BluxClient
+
+final class AddCartaddEventTests: XCTestCase {
+    func testBuildProducesCartaddEvent() throws {
+        let req = try AddCartaddEvent.Builder(itemId: "p1").build()
+        XCTAssertEqual(req.events.count, 1)
+        XCTAssertEqual(req.events[0].eventType, "cartadd")
+        XCTAssertEqual(req.events[0].eventProperties.itemId, "p1")
+    }
+
+    func testBuildWithCustomEventProperties() throws {
+        let req = try AddCartaddEvent.Builder(itemId: "p1")
+            .customEventProperties(["qty": .int(2)])
+            .build()
+        if case .int(2)? = req.events[0].customEventProperties?["qty"] {} else {
+            XCTFail()
+        }
+    }
+
+    func testEmptyItemIdThrows() {
+        XCTAssertThrowsError(try AddCartaddEvent.Builder(itemId: "").build())
+    }
+
+    func testTooLongItemIdThrows() {
+        let long = String(repeating: "x", count: 501)
+        XCTAssertThrowsError(try AddCartaddEvent.Builder(itemId: long).build())
+    }
+
+    func testItemId500CharsAllowed() throws {
+        let id500 = String(repeating: "x", count: 500)
+        let req = try AddCartaddEvent.Builder(itemId: id500).build()
+        XCTAssertEqual(req.events[0].eventProperties.itemId?.count, 500)
+    }
+
+    func testEncodingMatchesContract() throws {
+        let req = try AddCartaddEvent.Builder(itemId: "p").build()
+        let data = try JSONEncoder().encode(req.events[0])
+        let dict = try JSONSerialization.jsonObject(with: data) as! [String: Any]
+        XCTAssertEqual(dict["event_type"] as? String, "cartadd")
+        let props = dict["event_properties"] as! [String: Any]
+        XCTAssertEqual(props["item_id"] as? String, "p")
+    }
+}

--- a/Tests/BluxClientTests/builders/AddCustomEventTests.swift
+++ b/Tests/BluxClientTests/builders/AddCustomEventTests.swift
@@ -1,0 +1,50 @@
+import XCTest
+@testable import BluxClient
+
+final class AddCustomEventTests: XCTestCase {
+    func testBuildEmptyBuilderUsesProvidedEventType() throws {
+        let req = try AddCustomEvent.Builder(eventType: "wishlist_add").build()
+        XCTAssertEqual(req.events[0].eventType, "wishlist_add")
+    }
+
+    func testBuildWithAllFields() throws {
+        let req = try AddCustomEvent.Builder(eventType: "search")
+            .itemId("i")
+            .orderId("o")
+            .orderAmount(100)
+            .paidAmount(90)
+            .rating(4.5)
+            .page("results")
+            .addItem(id: "p1", price: 10, quantity: 1)
+            .customEventProperties(["q": .string("shoes")])
+            .build()
+
+        let event = req.events[0]
+        XCTAssertEqual(event.eventType, "search")
+        XCTAssertEqual(event.eventProperties.itemId, "i")
+        XCTAssertEqual(event.eventProperties.orderId, "o")
+        XCTAssertEqual(event.eventProperties.orderAmount, 100)
+        XCTAssertEqual(event.eventProperties.paidAmount, 90)
+        XCTAssertEqual(event.eventProperties.rating, 4.5)
+        XCTAssertEqual(event.eventProperties.page, "results")
+        XCTAssertEqual(event.eventProperties.items?.count, 1)
+    }
+
+    func testInvalidItemIdThrows() {
+        XCTAssertThrowsError(try AddCustomEvent.Builder(eventType: "x").itemId("").build())
+    }
+
+    func testInvalidOrderIdThrows() {
+        XCTAssertThrowsError(try AddCustomEvent.Builder(eventType: "x").orderId("").build())
+    }
+
+    func testInvalidPageThrows() {
+        XCTAssertThrowsError(try AddCustomEvent.Builder(eventType: "x").page("").build())
+    }
+
+    func testEmptyEventTypeIsAllowed() throws {
+        // Builder는 eventType 자체에 대한 검증은 하지 않음 (자유로움)
+        let req = try AddCustomEvent.Builder(eventType: "").build()
+        XCTAssertEqual(req.events[0].eventType, "")
+    }
+}

--- a/Tests/BluxClientTests/builders/AddLikeEventTests.swift
+++ b/Tests/BluxClientTests/builders/AddLikeEventTests.swift
@@ -1,0 +1,30 @@
+import XCTest
+@testable import BluxClient
+
+final class AddLikeEventTests: XCTestCase {
+    func testBuildProducesLikeEvent() throws {
+        let req = try AddLikeEvent.Builder(itemId: "p1").build()
+        XCTAssertEqual(req.events[0].eventType, "like")
+        XCTAssertEqual(req.events[0].eventProperties.itemId, "p1")
+    }
+
+    func testBuildWithCustomEventProperties() throws {
+        let req = try AddLikeEvent.Builder(itemId: "p1")
+            .customEventProperties(["source": .string("feed")])
+            .build()
+        if case .string("feed")? = req.events[0].customEventProperties?["source"] {} else {
+            XCTFail()
+        }
+    }
+
+    func testEmptyItemIdThrows() {
+        XCTAssertThrowsError(try AddLikeEvent.Builder(itemId: "").build())
+    }
+
+    func testEncodingShape() throws {
+        let req = try AddLikeEvent.Builder(itemId: "abc").build()
+        let data = try JSONEncoder().encode(req.events[0])
+        let dict = try JSONSerialization.jsonObject(with: data) as! [String: Any]
+        XCTAssertEqual(dict["event_type"] as? String, "like")
+    }
+}

--- a/Tests/BluxClientTests/builders/AddOrderEventTests.swift
+++ b/Tests/BluxClientTests/builders/AddOrderEventTests.swift
@@ -1,0 +1,98 @@
+import XCTest
+@testable import BluxClient
+
+final class AddOrderEventTests: XCTestCase {
+    func testBuildEmptyBuilderProducesOrderEvent() throws {
+        let req = try AddOrderEvent.Builder().build()
+        XCTAssertEqual(req.events.count, 1)
+        XCTAssertEqual(req.events[0].eventType, "order")
+    }
+
+    func testBuildWithOrderId() throws {
+        let req = try AddOrderEvent.Builder()
+            .orderId("ORD-1")
+            .build()
+        XCTAssertEqual(req.events[0].eventProperties.orderId, "ORD-1")
+    }
+
+    func testBuildWithAmounts() throws {
+        let req = try AddOrderEvent.Builder()
+            .orderAmount(100.0)
+            .paidAmount(80.0)
+            .build()
+        XCTAssertEqual(req.events[0].eventProperties.orderAmount, 100.0)
+        XCTAssertEqual(req.events[0].eventProperties.paidAmount, 80.0)
+    }
+
+    func testBuildWithItems() throws {
+        let req = try AddOrderEvent.Builder()
+            .addItem(id: "a", price: 10, quantity: 2)
+            .addItem(id: "b", price: 20, quantity: 1)
+            .build()
+        XCTAssertEqual(req.events[0].eventProperties.items?.count, 2)
+        XCTAssertEqual(req.events[0].eventProperties.items?[0].id, "a")
+        XCTAssertEqual(req.events[0].eventProperties.items?[1].quantity, 1)
+    }
+
+    func testBuildWithItemCustomProperties() throws {
+        let req = try AddOrderEvent.Builder()
+            .addItem(id: "a", price: 10, quantity: 1, customEventProperties: ["color": .string("red")])
+            .build()
+        let item = req.events[0].eventProperties.items?[0]
+        if case .string("red")? = item?.customEventProperties?["color"] {} else {
+            XCTFail("color custom prop missing")
+        }
+    }
+
+    func testBuildWithCustomEventProperties() throws {
+        let req = try AddOrderEvent.Builder()
+            .customEventProperties(["coupon": .string("SAVE10")])
+            .build()
+        if case .string("SAVE10")? = req.events[0].customEventProperties?["coupon"] {} else {
+            XCTFail()
+        }
+    }
+
+    func testEmptyOrderIdThrows() {
+        XCTAssertThrowsError(try AddOrderEvent.Builder().orderId("").build())
+    }
+
+    func testFluentChainingReturnsSameBuilder() throws {
+        let builder = AddOrderEvent.Builder()
+        let returned = builder
+            .orderId("X")
+            .orderAmount(1)
+            .paidAmount(1)
+        XCTAssertTrue(returned === builder, "chaining should return self for method chaining")
+    }
+
+    func testItemEncodingMatchesContract() throws {
+        let item = AddOrderEvent.Item(id: "p1", price: 99.99, quantity: 3)
+        let data = try JSONEncoder().encode(item)
+        let dict = try JSONSerialization.jsonObject(with: data) as! [String: Any]
+        XCTAssertEqual(dict["id"] as? String, "p1")
+        XCTAssertEqual(dict["price"] as? Double, 99.99)
+        XCTAssertEqual(dict["quantity"] as? Int, 3)
+    }
+
+    func testCompleteOrderEncodes() throws {
+        let req = try AddOrderEvent.Builder()
+            .orderId("O")
+            .orderAmount(200)
+            .paidAmount(180)
+            .addItem(id: "a", price: 100, quantity: 2)
+            .customEventProperties(["promo": .bool(true)])
+            .build()
+
+        let payload = req.getPayload()
+        XCTAssertEqual(payload.count, 1)
+        let data = try JSONEncoder().encode(payload[0])
+        let dict = try JSONSerialization.jsonObject(with: data) as! [String: Any]
+
+        XCTAssertEqual(dict["event_type"] as? String, "order")
+        let props = dict["event_properties"] as! [String: Any]
+        XCTAssertEqual(props["order_id"] as? String, "O")
+        XCTAssertEqual(props["order_amount"] as? Double, 200)
+        XCTAssertEqual(props["paid_amount"] as? Double, 180)
+    }
+}

--- a/Tests/BluxClientTests/builders/AddPageViewEventTests.swift
+++ b/Tests/BluxClientTests/builders/AddPageViewEventTests.swift
@@ -1,0 +1,30 @@
+import XCTest
+@testable import BluxClient
+
+final class AddPageViewEventTests: XCTestCase {
+    func testBuildProducesPageViewEvent() throws {
+        let req = try AddPageViewEvent.Builder(page: "home").build()
+        XCTAssertEqual(req.events[0].eventType, "page_view")
+        XCTAssertEqual(req.events[0].eventProperties.page, "home")
+    }
+
+    func testBuildWithCustomEventProperties() throws {
+        let req = try AddPageViewEvent.Builder(page: "home")
+            .customEventProperties(["scroll_depth": .double(0.75)])
+            .build()
+        if case .double(let v)? = req.events[0].customEventProperties?["scroll_depth"] {
+            XCTAssertEqual(v, 0.75, accuracy: 0.001)
+        } else {
+            XCTFail()
+        }
+    }
+
+    func testEmptyPageThrows() {
+        XCTAssertThrowsError(try AddPageViewEvent.Builder(page: "").build())
+    }
+
+    func testTooLongPageThrows() {
+        let long = String(repeating: "p", count: 501)
+        XCTAssertThrowsError(try AddPageViewEvent.Builder(page: long).build())
+    }
+}

--- a/Tests/BluxClientTests/builders/AddPageVisitEventTests.swift
+++ b/Tests/BluxClientTests/builders/AddPageVisitEventTests.swift
@@ -1,0 +1,24 @@
+import XCTest
+@testable import BluxClient
+
+final class AddPageVisitEventTests: XCTestCase {
+    func testBuildProducesPageVisitEvent() throws {
+        let req = try AddPageVisitEvent.Builder().build()
+        XCTAssertEqual(req.events[0].eventType, "page_visit")
+    }
+
+    func testBuildWithCustomEventProperties() throws {
+        let req = try AddPageVisitEvent.Builder()
+            .customEventProperties(["referrer": .string("google")])
+            .build()
+        if case .string("google")? = req.events[0].customEventProperties?["referrer"] {} else {
+            XCTFail()
+        }
+    }
+
+    func testNoSetters() throws {
+        let req = try AddPageVisitEvent.Builder().build()
+        XCTAssertNil(req.events[0].eventProperties.itemId)
+        XCTAssertNil(req.events[0].eventProperties.page)
+    }
+}

--- a/Tests/BluxClientTests/builders/AddProductDetailViewEventTests.swift
+++ b/Tests/BluxClientTests/builders/AddProductDetailViewEventTests.swift
@@ -1,0 +1,23 @@
+import XCTest
+@testable import BluxClient
+
+final class AddProductDetailViewEventTests: XCTestCase {
+    func testBuildProducesPDVEvent() throws {
+        let req = try AddProductDetailViewEvent.Builder(itemId: "p1").build()
+        XCTAssertEqual(req.events[0].eventType, "product_detail_view")
+        XCTAssertEqual(req.events[0].eventProperties.itemId, "p1")
+    }
+
+    func testBuildWithCustomEventProperties() throws {
+        let req = try AddProductDetailViewEvent.Builder(itemId: "p1")
+            .customEventProperties(["recommended": .bool(true)])
+            .build()
+        if case .bool(true)? = req.events[0].customEventProperties?["recommended"] {} else {
+            XCTFail()
+        }
+    }
+
+    func testEmptyItemIdThrows() {
+        XCTAssertThrowsError(try AddProductDetailViewEvent.Builder(itemId: "").build())
+    }
+}

--- a/Tests/BluxClientTests/builders/AddRateEventTests.swift
+++ b/Tests/BluxClientTests/builders/AddRateEventTests.swift
@@ -1,0 +1,40 @@
+import XCTest
+@testable import BluxClient
+
+final class AddRateEventTests: XCTestCase {
+    func testBuildProducesRateEvent() throws {
+        let req = try AddRateEvent.Builder(itemId: "p1", rating: 5.0).build()
+        XCTAssertEqual(req.events[0].eventType, "rate")
+        XCTAssertEqual(req.events[0].eventProperties.itemId, "p1")
+        XCTAssertEqual(req.events[0].eventProperties.rating, 5.0)
+    }
+
+    func testBuildWithCustomEventProperties() throws {
+        let req = try AddRateEvent.Builder(itemId: "p1", rating: 4.5)
+            .customEventProperties(["category": .string("good")])
+            .build()
+        if case .string("good")? = req.events[0].customEventProperties?["category"] {} else {
+            XCTFail()
+        }
+    }
+
+    func testEmptyItemIdThrows() {
+        XCTAssertThrowsError(try AddRateEvent.Builder(itemId: "", rating: 4.0).build())
+    }
+
+    func testRatingZeroAllowed() throws {
+        let req = try AddRateEvent.Builder(itemId: "p", rating: 0).build()
+        XCTAssertEqual(req.events[0].eventProperties.rating, 0)
+    }
+
+    func testRatingNegativeAllowed() throws {
+        // setRating은 검증 없음 (Validator 호출 안 함)
+        let req = try AddRateEvent.Builder(itemId: "p", rating: -1).build()
+        XCTAssertEqual(req.events[0].eventProperties.rating, -1)
+    }
+
+    func testRatingFractional() throws {
+        let req = try AddRateEvent.Builder(itemId: "p", rating: 3.7).build()
+        XCTAssertEqual(req.events[0].eventProperties.rating, 3.7)
+    }
+}

--- a/Tests/BluxClientTests/support/SdkStateGuard.swift
+++ b/Tests/BluxClientTests/support/SdkStateGuard.swift
@@ -1,0 +1,65 @@
+import Foundation
+@testable import BluxClient
+
+/// SdkConfig + EventHandlers + ColdStartNotificationManager의 정적 상태를 테스트마다 격리한다.
+/// SDK 전반의 정적 슬롯을 한 곳에서 관리해 setUp/tearDown 누락으로 인한 테스트 간 누수를 방지.
+///
+/// 사용:
+///   override func setUp() { super.setUp(); guardian = SdkStateGuard(); guardian.clear() }
+///   override func tearDown() { guardian.restore(); super.tearDown() }
+final class SdkStateGuard {
+    private var savedClientId: String?
+    private var savedApiKey: String?
+    private var savedBluxId: String?
+    private var savedDeviceId: String?
+    private var savedUserId: String?
+    private var savedLogLevel: LogLevel
+    private var savedSessionId: String
+    private var savedRequestPermissionOnLaunch: Bool
+
+    init() {
+        savedClientId = SdkConfig.clientIdInUserDefaults
+        savedApiKey = SdkConfig.apiKeyInUserDefaults
+        savedBluxId = SdkConfig.bluxIdInUserDefaults
+        savedDeviceId = SdkConfig.deviceIdInUserDefaults
+        savedUserId = SdkConfig.userIdInUserDefaults
+        savedLogLevel = SdkConfig.logLevel
+        savedSessionId = SdkConfig.sessionId
+        savedRequestPermissionOnLaunch = SdkConfig.requestPermissionOnLaunch
+    }
+
+    func clear() {
+        SdkConfig.clientIdInUserDefaults = nil
+        SdkConfig.apiKeyInUserDefaults = nil
+        SdkConfig.bluxIdInUserDefaults = nil
+        SdkConfig.deviceIdInUserDefaults = nil
+        SdkConfig.userIdInUserDefaults = nil
+
+        EventHandlers.unhandledNotification = nil
+        EventHandlers.notificationClicked = nil
+        EventHandlers.notificationForegroundWillDisplay = nil
+        EventHandlers.inAppCustomActionHandlers = []
+
+        ColdStartNotificationManager.coldStartNotification = nil
+        ColdStartNotificationManager.reset()
+    }
+
+    func restore() {
+        SdkConfig.clientIdInUserDefaults = savedClientId
+        SdkConfig.apiKeyInUserDefaults = savedApiKey
+        SdkConfig.bluxIdInUserDefaults = savedBluxId
+        SdkConfig.deviceIdInUserDefaults = savedDeviceId
+        SdkConfig.userIdInUserDefaults = savedUserId
+        SdkConfig.logLevel = savedLogLevel
+        SdkConfig.sessionId = savedSessionId
+        SdkConfig.requestPermissionOnLaunch = savedRequestPermissionOnLaunch
+
+        EventHandlers.unhandledNotification = nil
+        EventHandlers.notificationClicked = nil
+        EventHandlers.notificationForegroundWillDisplay = nil
+        EventHandlers.inAppCustomActionHandlers = []
+
+        ColdStartNotificationManager.coldStartNotification = nil
+        ColdStartNotificationManager.reset()
+    }
+}


### PR DESCRIPTION
## 요약

BluxClient SDK에 단위 테스트와 브릿지 contract 테스트를 추가합니다. 405개 테스트 통과.

기존에는 SDK 자체에 대한 테스트가 거의 없어 회귀를 잡기 어려웠고, Web / RN / Flutter SDK가 의존하는 부분도 검증되지 않았습니다.

## 변경 내용

- SDK 핵심 모듈(events, services, models 등) 단위 테스트
- Web / RN / Flutter SDK가 사용하는 인터페이스가 깨지지 않는지 검증하는 테스트
- SPM testTarget 2개 등록 (BluxClientTests / BluxClientPublicAPITests)
- CI에 SPM device build + simulator test 단계 추가
- \`BluxWebSdkBridge\`에 단위 테스트용 internal 메서드 한 줄 분리 (외부 동작 변화 없음)

## 검증 방법

xcodebuild iOS Simulator에서 405 tests 통과 (~7초). CI도 같은 명령으로 실행됩니다.

## 테스트 체크리스트

- [ ] CI 통과
- [ ] SDK 사용에 영향 없음 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)