### PR TITLE
fix: Web SDK 브릿지 customDeviceId payload + 빈 값 normalize

### DIFF
--- a/BluxClient/Classes/BluxWebSdkBridge.swift
+++ b/BluxClient/Classes/BluxWebSdkBridge.swift
@@ -112,7 +112,14 @@ private extension BluxWebSdkBridge {
         }
 
         let requestPermission = (dict["requestPermissionOnLaunch"] as? Bool) ?? true
-        BluxClient.initialize(nil, bluxApplicationId: appId, bluxAPIKey: apiKey, requestPermissionOnLaunch: requestPermission)
+        let customDeviceId = dict["customDeviceId"] as? String
+        BluxClient.initialize(
+            nil,
+            bluxApplicationId: appId,
+            bluxAPIKey: apiKey,
+            requestPermissionOnLaunch: requestPermission,
+            customDeviceId: customDeviceId
+        )
     }
 
     func handleSignIn(_ payload: Any?) {

--- a/BluxClient/Classes/DeviceService.swift
+++ b/BluxClient/Classes/DeviceService.swift
@@ -38,7 +38,8 @@ enum DeviceService {
     ) {
         let body = getBluxDeviceInfo()
         body.deviceId = deviceId
-        body.customDeviceId = customDeviceId
+        let trimmedCustomDeviceId = customDeviceId?.trimmingCharacters(in: .whitespacesAndNewlines)
+        body.customDeviceId = (trimmedCustomDeviceId?.isEmpty == false) ? trimmedCustomDeviceId : nil
 
         guard let clientId = SdkConfig.clientIdInUserDefaults else {
             completion(.failure(NSError(domain: "DeviceService", code: -1, userInfo: [NSLocalizedDescriptionKey: "Client ID not found"])))

--- a/Tests/BluxClientTests/BluxWebSdkBridgeTests.swift
+++ b/Tests/BluxClientTests/BluxWebSdkBridgeTests.swift
@@ -158,6 +158,9 @@ final class BluxWebSdkBridgeTests: XCTestCase {
         XCTAssertNil(SdkConfig.apiKeyInUserDefaults)
     }
 
+    // customDeviceId 변종 테스트는 위 MARK 주석과 같은 이유(prod HTTP 도달)로 두지 않는다.
+    // forward 자체는 코드 inspection으로 보장 (BluxWebSdkBridge.swift handleInitialize).
+
     // MARK: - signIn
 
     func testSignInWithUserIdInvokesSDKWithoutCrash() {


### PR DESCRIPTION
## Summary

Web SDK가 보내는 customDeviceId가 iOS SDK에서 무시되던 두 가지 문제를 수정합니다.

### 1. `fix: Web SDK 브릿지가 customDeviceId payload를 무시하던 버그 수정`

Web SDK는 initialize 시 `customDeviceId`를 함께 전달하는데, iOS의 `BluxWebSdkBridge.handleInitialize`가 이 필드를 무시하고 SDK에 넘기지 않았습니다. 결과적으로 사용자가 customDeviceId를 지정해도 적용되지 않아 동일 사용자가 새 익명 device로 잡히는 문제가 발생.

수정: dictionary에서 `customDeviceId`를 추출해 `BluxClient.initialize`에 함께 전달.

알려진 한계: SDK가 이미 같은 credentials로 초기화된 상태에서 web bridge가 다시 `initialize`를 호출하면, `BluxClient.initialize`가 early return하면서 customDeviceId가 무시됩니다. 즉 이 fix는 첫 번째 init에서만 적용됩니다 (예: 하이브리드 앱에서 native가 먼저 init하고 web이 나중에 init하는 경우 customDeviceId가 안 들어감). 이미 activated된 상황에서의 customDeviceId 갱신은 별도 setter나 update 경로 설계가 필요.

### 2. `fix: customDeviceId 빈 문자열/whitespace를 nil로 normalize`

빈 문자열(`""`)이나 공백만 있는 customDeviceId가 들어오면 nil로 정리한 뒤 서버에 전송합니다. `DeviceService.initializeDevice` 진입점에서 한 번 처리하므로 Web/RN/Flutter/native 모든 호출 경로가 자동으로 보호됩니다.

서버는 `custom_device_id`를 device identity key로 사용하는데:
- 빈 문자열로 들어온 여러 device가 모두 같은 식별자로 묶여 사용자 데이터가 섞일 위험
- 공백 차이(`"abc"` vs `"abc "`)로 같은 사용자가 별개 device로 분리될 위험

이 두 가지를 한 줄짜리 trim + isEmpty 체크로 차단합니다.

Android PR과 동일 패턴 (zaikorea/Blux-Android-SDK#78).

## Test plan

- [x] xcodebuild iOS Simulator (SPM testTarget) 단위 테스트 통과