### PR TITLE
ci: Install iOS platform 단계에 retry 추가

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,19 @@ jobs:
           xcode-version: "26.0.1"
 
       - name: Install iOS platform
-        run: xcodebuild -downloadPlatform iOS
+        run: |
+          # macos-26 runner에는 iOS 26 platform이 사전 설치돼 있지 않아 매번 다운로드가 필요하다.
+          # 그런데 Apple 다운로드 서버 연결이 가끔 끊겨서 그대로 실패하는 일이 잦다.
+          # 그래서 30초 간격으로 최대 3번 재시도한다 (이미 설치돼 있으면 다운로드는 빠르게 끝남).
+          for attempt in 1 2 3; do
+            if xcodebuild -downloadPlatform iOS; then
+              exit 0
+            fi
+            echo "downloadPlatform attempt $attempt failed, retrying in 30s..."
+            sleep 30
+          done
+          echo "downloadPlatform failed after 3 attempts"
+          exit 1
 
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1


### PR DESCRIPTION
## Summary

CI의 `Install iOS platform` 단계 (`xcodebuild -downloadPlatform iOS`)가 Apple 다운로드 서버와 연결 실패로 자주 실패합니다 (`"Unable to connect to simulator"`, exit code 70). 매 PR push마다 절반 정도 확률로 발생해 매번 재실행이 필요했음. 코드 문제가 아니라 외부 서버의 일시적 장애.

이 PR은 macOS 26 / Xcode 26 환경(로컬과 동일)을 그대로 유지하면서 다운로드 단계만 더 견고하게 만듭니다.

수정 내용:
- 다운로드 실패 시 최대 3번까지 재시도, 시도 사이 30초 대기.
- 이미 설치된 환경에서도 `downloadPlatform`은 빠르게 끝나므로 매번 호출해도 손해 없음.

검토했지만 채택하지 않은 대안:
- **runner를 macOS 15 + Xcode 16으로 낮추기** → iOS 18 SDK가 사전 설치돼 있어 다운로드 단계 자체가 불필요. 다만 로컬 환경(macOS 26 + Xcode 26)과 차이가 생겨 "CI에서만 재현되는 컴파일 에러" 같은 디버깅이 어려워질 수 있음. 환경 일치를 더 우선시.
- **iOS 플랫폼 디렉토리를 GitHub Actions 캐시에 보관** → 디렉토리가 수 GB라 압축/복원 비용이 다운로드 시간보다 클 수 있어 효과 미미.

## Test plan

- [x] CI 통과 (이 PR 자체로 retry 로직 검증)