### PR TITLE
docs: CLAUDE.md + pitfalls.md로 SDK 가이드 통합

### DIFF
--- a/.claude/docs/pitfalls.md
+++ b/.claude/docs/pitfalls.md
@@ -1,0 +1,85 @@
+# 반복된 버그 패턴 / Race / Drain 정책
+
+"이미 한 번 터졌던" 함정만 모은다. 같은 실수를 다시 만들지 않기 위해. 자세한 코드는 실제 파일 참고.
+
+## 1. Credential 전환 drain 누락 (57af3ef, b3072e5)
+
+signOut → 다른 user signIn / hybrid 앱 페이지 전환 재초기화 / stage 전환 후 재초기화 시, 이전 세션의 정적 상태가 새 세션에 새면서 attribution 오염 + 잘못된 인앱 표시.
+
+[BluxClient.swift](../../BluxClient/Classes/BluxClient.swift) `initialize`(credential 변경 분기) + `signOut` **양쪽에 똑같이** 5종 drain:
+
+```swift
+EventHandlers.unhandledNotification = nil
+EventService.clearPendingBatch()
+InappService.dismissCurrentInApp()
+InappService.clearInappQueue()
+EventQueue.shared.clearPending()
+```
+
+credential 변경 시 추가: `isActivated = false`, `ColdStartNotificationManager.reset()`, `clientId` 달라졌으면 `deviceId` 폐기.
+
+**금지**: 한쪽에만 추가. 새 정적 슬롯은 **양쪽 + `SdkStateGuard`까지 세 곳**에 등록.
+
+## 2. customDeviceId 정규화 + 새 파라미터 4곳 동기화 (f657254, 60f9ca0)
+
+빈 문자열/whitespace `customDeviceId`가 그대로 전송 → 모든 device가 같은 빈 식별자로 merge. 또한 [BluxWebSdkBridge.swift](../../BluxClient/Classes/BluxWebSdkBridge.swift) `handleInitialize`가 payload 추출 빠뜨려 silent drop.
+
+**해결**: [DeviceService.swift](../../BluxClient/Classes/DeviceService.swift)에서 trim + 빈 문자열 → nil. 브릿지 핸들러는 payload 명시 추출.
+
+**교훈 — 새 public 파라미터 추가 시 4곳 동기화**:
+1. `BluxClient.swift` 본체
+2. `BluxWebSdkBridge.handleInitialize` 등 브릿지 액션 핸들러
+3. `Tests/BluxClientPublicAPITests/PublicAPISurfaceTests.swift` 시그니처 캡처
+4. RN wrapper(Blux-RN-SDK), Flutter wrapper(Blux-Flutter-SDK) binding
+
+빠뜨리면 Web SDK 브릿지만 죽고 wrapper 테스트로는 안 잡힌다.
+
+## 3. 폴링 백오프 24h 이상은 그대로 유지 (91df32b)
+
+[EventService.swift](../../BluxClient/Classes/EventService.swift) 실패 백오프:
+
+```swift
+let dayCapMs = 1000 * 60 * 60 * 24
+let nextPollDelay = cachedPollDelayMs >= dayCapMs
+    ? cachedPollDelayMs                              // 24h 이상이면 그대로 유지
+    : min(cachedPollDelayMs * 2, dayCapMs)           // 24h까지만 2배
+```
+
+**왜 24h 이상은 cap 안 하나** — 서버가 의도적 disable 시 큰 값(`nextPollDelayMs=10일`)을 내려준다. 클라가 24h로 단축하면 서버 의도 깨짐.
+
+**금지**: `min(*2, 24h)`로 단순화. ternary 분기를 그대로 유지.
+
+## 4. push_opened dedup — 3중 가드 (fdeff7f)
+
+WebView 브릿지 환경에서 페이지 전환마다 `initialize`가 재호출되며 같은 `launchOptions`가 재전달 → `push_opened` CRM 이벤트 N번 전송.
+
+[ColdStartNotificationManager.swift](../../BluxClient/Classes/ColdStartNotificationManager.swift)의 세 가드가 함께:
+
+1. **`hasProcessedLaunchOptions`** — launchOptions 재처리 차단. `setColdStartNotification`이 nil 받았을 땐 set 안 함 (initialize(nil, ...) → initialize(launchOptions, ...) 시퀀스 보존).
+2. **`lastOpenedNotificationId`** — launchOptions 경로 + `BluxNotificationCenter.didReceive` 경로 모두 `trackOpen`을 거치며 동일 ID는 한 번만. **`reset()`이 이 슬롯은 비우지 않는다** (서버 발급 ObjectId라 credential 경계 넘어도 dedup 키로 유효).
+3. **credential switch 시 launchOptions 차단** — `isInProcessCredentialSwitch ? nil : launchOptions`로 이전 credential 페이로드 재처리 방지.
+
+**금지**: 셋 중 하나만 변경. 셋이 함께 굴러가야 안전.
+
+## 5. HTTPClient completion 누락 + initialize 실패 롤백 (596b216, d91a680)
+
+두 케이스 묶음 — 둘 다 "콜백/플래그 안 풀려서 큐 영구 막힘" 패턴.
+
+- `createRequest`/`createRequestWithBody`가 nil 반환 시 `completion(nil, .invalidRequest)` 호출 필수. 안 하면 `EventQueue.addEvent`의 `done` 콜백 안 불려 다음 태스크 영구 대기.
+- `DeviceService.initializeDevice` 실패 콜백에서 `isActivated = false` 롤백 필수. 안 하면 재시도 시 short-circuit return으로 영원히 초기화 못 함.
+
+**금지**: 새 HTTP 메서드 / 비동기 진입점 추가 시 모든 실패 분기에서 콜백/플래그 풀어주는 코드 누락.
+
+## 6. 인앱 동시성 가드 3종
+
+[InappService.swift](../../BluxClient/Classes/InappService.swift)의 세 가드가 함께 굴러야 인앱 정상. 셋 중 하나라도 약화하면 동시 두 개 표시 / stale window leak / WebView crash.
+
+1. **`processWebViewQueue`의 `dispatchPrecondition(.onQueue(.main))`** — 메인 스레드 강제. 멀티스레드에서 큐 head를 동시에 꺼내면 인앱 두 개 표시.
+2. **`presentInappWebview`의 `didSwitchToBanner` 플래그** — HTML이 `resize` 여러 번 호출해도 모달→배너 swap을 한 번만. 없으면 stale `BannerWindow` leak.
+3. **`handleInappResponse` → `DispatchQueue.main.async`** — `URLSession` 콜백은 백그라운드. WebView 생성/표시는 메인 강제.
+
+## 7. notificationUrlOpenOptions 콜드 스타트 리셋 (54262d9)
+
+[SdkConfig.swift](../../BluxClient/Classes/SdkConfig.swift)의 `notificationUrlOpenOptions`는 App Group `UserDefaults`에 raw Int로 영속. 콜드 스타트 후에도 호스트가 설정한 값 유지. 옵션 저장/복원 경로 변경 시 `BluxClientTests.testSetNotificationUrlOpenOptionsPersists`로 락-인.
+
+**금지**: 메모리 변수만으로 단순화 — process kill → 콜드 스타트에서 기본값으로 리셋 회귀.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,68 +1,60 @@
 # Blux iOS SDK
 
-iOS용 행동 분석 및 인앱 메시징 SDK
+iOS용 행동 분석 / 인앱 메시징 / 푸시 SDK. Swift, CocoaPods + SPM. RN/Flutter wrapper SDK가 이 모듈을 그대로 import해 사용.
 
-## 프로젝트 구조
-
-```text
-BluxClient/Classes/     # SDK 소스 코드
-├── BluxClient.swift    # 메인 API 파사드
-├── services/           # 핵심 서비스 (Event, Inapp, Device, HTTP)
-├── events/             # 이벤트 타입들 (Order, Cart, PageView 등)
-├── request/            # API 요청/응답 모델
-├── views/              # WebView, BannerWindow 등 UI 컴포넌트
-├── notification/       # 푸시 알림 관련
-└── utilities/          # Logger, Validator, 유틸리티
-
-Example/                # CocoaPods 예제 앱
-ExampleSPM/             # Swift Package Manager 예제 앱
-```
-
-## 빌드 시스템
-
-- **CocoaPods**: `BluxClient.podspec` (주요 배포)
-- **SPM**: `Package.swift`
-- **최소 지원**: iOS 13.0+, Swift 5.0+
-
-## 개발 워크플로우
-
-### Example 앱 빌드 (CocoaPods)
+## 자주 쓰는 명령
 
 ```bash
-cd Example
-pod install
-open BluxExample.xcworkspace
+cd Example && bundle exec pod install && open BluxExample.xcworkspace        # Example 앱
+xcodebuild -scheme BluxClient -destination 'platform=iOS Simulator,name=iPhone 15' test   # 단위 테스트
+BLUX_STAGE=stg bundle exec pod lib lint BluxClient.podspec --allow-warnings --skip-tests  # podspec lint
+./scripts/release-personal.sh                                                # 개인 stg 배포
 ```
 
-### SPM 예제
+## 절대 어기지 말 것
 
-```bash
-cd ExampleSPM
-open BluxExampleSPM.xcodeproj
-```
+- **버전 SSoT는 [`BluxClient/Classes/SdkConfig.swift`](BluxClient/Classes/SdkConfig.swift)의 `sdkVersion` 한 군데.** podspec / 워크플로우 / 배포 스크립트 모두 정규식으로 이 값을 읽음. 수동 git tag 만들지 말고 release 워크플로우에 위임 — release-prod는 `release/x.y.z` 브랜치 + workflow_dispatch, release-internal은 main push 자동, personal은 [`scripts/release-personal.sh`](scripts/release-personal.sh). **단 prod만 SSoT 일관성 보장** (sed → commit → tag). **internal/personal은 태그 push 후 `SdkConfig.swift`를 임시 수정만** (커밋 안 함) — git tag가 가리키는 source의 `sdkVersion`은 base 그대로이고 podspec `spec.version`만 풀 태그. 따라서 internal/personal SDK가 송출하는 `X-BLUX-SDK-INFO` 헤더는 base 버전이며 풀 버전 식별은 `Podfile.lock` / 태그명으로 해야 한다.
 
-### SDK 배포
+- **`Stage.setStage`는 `defaultStage == .prod`일 때만 차단된다.** "prod 빌드 = 차단"이 아님. [Stage.swift](BluxClient/Classes/Stage.swift)는 **Info.plist `BluxStage` → 컴파일 플래그(`BLUX_LOCAL/DEV/STG`) → 기본 `.prod`** 순으로 결정. 호스트가 Info.plist에 `BluxStage=stg`를 박으면 prod 분기 빌드라도 런타임 stage 전환이 가능. **prod 출시 빌드는 Info.plist에 `BluxStage` 키 없거나 명시적으로 `prod`이어야** 가드 의도대로 동작.
 
-1. `BluxClient.podspec`에서 버전 업데이트
-2. `Package.swift`에서 버전 태그 확인
-3. 태그 생성: `git tag X.Y.Z && git push origin X.Y.Z`
+- **세션 경계 청소는 [`initialize`](BluxClient/Classes/BluxClient.swift)(credential 변경) + `signOut` 양쪽에 똑같이.** 한쪽만 수정하면 회귀. 5종 정적 슬롯(`EventHandlers.unhandledNotification` / `EventService.clearPendingBatch` / `InappService.dismissCurrentInApp` / `InappService.clearInappQueue` / `EventQueue.shared.clearPending`) + credential 변경 시 `isActivated=false` / `ColdStartNotificationManager.reset()`. 새 정적 슬롯 추가 시 양쪽 + [`SdkStateGuard`](Tests/BluxClientTests/support/SdkStateGuard.swift)까지 세 곳에 등록. 자세한 사고 이력은 [.claude/docs/pitfalls.md #1](.claude/docs/pitfalls.md#1-credential-전환-drain-누락-57af3ef-b3072e5).
 
-## 주요 컴포넌트
+- **외부 의존성 추가 금지.** `URLSession` + `Codable` + `WKWebView` 표준만. 호스트 앱에 dynamic framework로 들어가므로 의존성 충돌이 호스트 빌드를 깨뜨림.
 
-| 파일                  | 역할                                     |
-| --------------------- | ---------------------------------------- |
-| `BluxClient.swift`    | SDK 초기화, 사용자 인증, 이벤트 전송 API |
-| `EventService.swift`  | 이벤트 배칭(100ms), 폴링, 전송           |
-| `InappService.swift`  | 인앱 메시지 표시 (모달/배너/팝업)        |
-| `HTTPClient.swift`    | API 통신 (PROD/STG/DEV/LOCAL)            |
-| `DeviceService.swift` | 디바이스 정보, 푸시 토큰 관리            |
+- **`BluxClient`에 새 public 파라미터 추가 시 4곳 동기화.** (1) [`BluxClient.swift`](BluxClient/Classes/BluxClient.swift) 본체, (2) [`BluxWebSdkBridge.handleInitialize`](BluxClient/Classes/BluxWebSdkBridge.swift) 등 브릿지 액션 핸들러, (3) [`Tests/BluxClientPublicAPITests/PublicAPISurfaceTests.swift`](Tests/BluxClientPublicAPITests/PublicAPISurfaceTests.swift) 시그니처 캡처, (4) RN(Blux-RN-SDK) / Flutter(Blux-Flutter-SDK) wrapper binding. 빠뜨리면 Web SDK 브릿지 / wrapper만 silent하게 죽음. 자세한 사고 이력은 [.claude/docs/pitfalls.md #2](.claude/docs/pitfalls.md#2-customdeviceid-정규화--새-파라미터-4곳-동기화-f657254-60f9ca0).
 
-## 커밋 컨벤션
+## 호스트 앱 통합 (수동 작업)
+
+iOS는 자동 등록 메커니즘이 없어 호스트 앱이 명시적으로 다음을 해야 한다. 살아있는 reference: [Example/](Example/).
+
+1. **App Group capability** — 호스트 + NSE 양쪽 entitlements + 양쪽 Info.plist `BluxAppGroupName` 키. 미설정 시 NSE에서 `bluxClientId`/`bluxAPIKey` 못 봐서 `trackReceived` 실패.
+2. **APNs entitlement** + Info.plist `UIBackgroundModes = [remote-notification]`.
+3. **NSE 타겟** + `BluxNotificationServiceExtensionHelper.shared.didReceive` 위임 ([Example/BluxNotificationServiceExtension/NotificationService.swift](Example/BluxNotificationServiceExtension/NotificationService.swift)).
+4. **AppDelegate 위임 4개 메서드** — `didFinishLaunchingWithOptions`에서 `BluxClient.initialize` + `UNUserNotificationCenter.current().delegate = self`, `didRegisterForRemoteNotificationsWithDeviceToken` → `BluxAppDelegate.shared`, `userNotificationCenter(_:didReceive:)` / `(_:willPresent:)` → `BluxNotificationCenter.shared`. swizzling은 의도적으로 안 씀 — 호스트가 자체 delegate 가질 때 chain 깨지는 사고 이력. ([Example/BluxExample/AppDelegate.swift](Example/BluxExample/AppDelegate.swift))
+
+## 자주 깨지는 곳 (운영)
+
+| 증상 | 원인/해결 |
+|------|----------|
+| `Podfile.lock is stale` (CI) | 로컬에서 `cd Example && bundle exec pod install --repo-update` 후 lock 커밋 |
+| `Unexpected CocoaPods version` | 시스템 `pod`이 1.16.2 아님. 항상 `bundle exec pod ...` 사용 |
+| `xcodebuild -downloadPlatform iOS` 실패 | macos-26 runner에 iOS platform 매번 다운로드 필요. 30초 간격 3회 자동 재시도 (8aa3f6c). 서버 일시 장애면 워크플로우 재실행 |
+| `No available iPhone Simulator found` | runner 변경. CI가 `xcrun simctl list devices available -j \| jq`로 동적 선택. 셀렉터 점검 |
+| Wrapper SDK 빌드 깨짐 | public 시그니처 변경. `PublicAPISurfaceTests` 동기화 + RN/Flutter 측 release 필요 |
+| CocoaPods trunk 토큰 만료 | `pod trunk register development@zaikorea.org 'Blux'` → 메일 인증 → 재실행. 로컬은 `~/.netrc`에서 자동 로드 |
+
+## 커밋 prefix
 
 ```text
-feat: 새 기능
-fix: 버그 수정
-refactor: 리팩토링
-build: 빌드/배포 관련
-feat(example): 예제 앱 관련
+feat / fix / refactor / build / ci / test / chore / docs / feat(example)
 ```
+
+이슈/PR 번호는 끝에 ` (#NN)`. PR 템플릿은 [.github/pull_request_template.md](.github/pull_request_template.md). CODEOWNERS: `@geongun20 @silvermanseoul @NoMoreViolence`.
+
+## 추가 컨텍스트
+
+- **반복 발생한 버그 패턴 / race / drain 정책** → [.claude/docs/pitfalls.md](.claude/docs/pitfalls.md)
+- **Stage / 워크플로우 / 빌드 도구 버전** → [.github/workflows/](.github/workflows/), [BluxClient.podspec](BluxClient.podspec), [Gemfile](Gemfile)
+- **호스트 통합 reference** → [Example/](Example/)
+
+코드 / git log / `.github/` / `Example/`을 직접 보면 알 수 있는 정보는 docs에 두지 않는다. 위 4곳에 없는 합의된 invariant와 사고 이력만 보존.


### PR DESCRIPTION
# 📝 Changes

기존 CLAUDE.md를 합의된 invariant + 사고 이력만 보존하는 형태로 재구성.

- **`CLAUDE.md` (60라인)**: 자주 쓰는 명령 / 절대 어기지 말 것 land mine 5종 (버전 SSoT / Stage 가드 / 세션 경계 / 외부 의존성 / 4곳 동기화) / 호스트 통합 수동 작업 4단계 (App Group / NSE / AppDelegate 위임) / 자주 깨지는 곳 운영 표 / 커밋 prefix.
- **`.claude/docs/pitfalls.md` (85라인)**: 7개 사고 이력 — credential 전환 drain (57af3ef, b3072e5) / customDeviceId + 4곳 동기화 (f657254, 60f9ca0) / 폴링 백오프 24h 이상 유지 (91df32b) / push_opened 3중 dedup (fdeff7f) / HTTPClient completion + isActivated 롤백 (596b216, d91a680) / 인앱 동시성 가드 3종 / `notificationUrlOpenOptions` 영속 (54262d9).
- 코드 / git log / `.github/` / `Example/`을 직접 보면 알 수 있는 정보는 docs에 두지 않음.

# Tests you conducted

- Docs-only 변경, 런타임/CI 영향 없음.

# ⛑ QA Test Cases

- [x] 테스트가 필요 없습니다 (docs-only)