### PR TITLE
feat: 인앱 메시지 URL 오픈 정책을 InAppUrlOpenOptions로 외부 제어

### DIFF
--- a/BluxClient/Classes/BluxClient.swift
+++ b/BluxClient/Classes/BluxClient.swift
@@ -213,6 +213,10 @@ struct UpdatePropertiesBody: Codable {
         SdkConfig.notificationUrlOpenOptions = options
     }
 
+    @objc public static func setInAppUrlOpenOptions(_ options: InAppUrlOpenOptions) {
+        SdkConfig.inAppUrlOpenOptions = options
+    }
+
     /// Set userId of the device
     @objc public static func signIn(userId: String, completion: @escaping ((NSError?) -> Void) = { _ in }) {
         guard

--- a/BluxClient/Classes/InAppUrlOpenOptions.swift
+++ b/BluxClient/Classes/InAppUrlOpenOptions.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+@objcMembers
+public final class InAppUrlOpenOptions: NSObject {
+    public let httpUrlOpenTarget: HttpUrlOpenTarget
+
+    public init(httpUrlOpenTarget: HttpUrlOpenTarget = .internalWebView) {
+        self.httpUrlOpenTarget = httpUrlOpenTarget
+        super.init()
+    }
+}

--- a/BluxClient/Classes/InappService.swift
+++ b/BluxClient/Classes/InappService.swift
@@ -267,16 +267,25 @@ class InappService {
                                         switch scheme {
                                         case "http", "https":
                                             createInappOpened(notificationId)
-                                            dismissBannerWindow {
-                                                DispatchQueue.main.async {
-                                                    if let topController = UIViewController.getTopViewController(),
-                                                       topController.view.window != nil {
-                                                        let newWebViewController = WebViewController(content: .url(url))
-                                                        let navigationController = UINavigationController(rootViewController: newWebViewController)
-                                                        navigationController.modalPresentationStyle = .fullScreen
-                                                        topController.present(navigationController, animated: true, completion: nil)
+                                            switch SdkConfig.inAppUrlOpenOptions.httpUrlOpenTarget {
+                                            case .internalWebView:
+                                                dismissBannerWindow {
+                                                    DispatchQueue.main.async {
+                                                        if let topController = UIViewController.getTopViewController(),
+                                                           topController.view.window != nil {
+                                                            let newWebViewController = WebViewController(content: .url(url))
+                                                            let navigationController = UINavigationController(rootViewController: newWebViewController)
+                                                            navigationController.modalPresentationStyle = .fullScreen
+                                                            topController.present(navigationController, animated: true, completion: nil)
+                                                        }
                                                     }
                                                 }
+                                            case .externalBrowser:
+                                                dismissBannerWindow {
+                                                    UIApplication.shared.open(url, options: [:])
+                                                }
+                                            case .none:
+                                                dismissBannerWindow()
                                             }
                                         default:
                                             dismissBannerWindow {
@@ -350,32 +359,39 @@ class InappService {
                             switch scheme {
                             case "http", "https":
                                 createInappOpened(notificationId)
-                                // 기존 웹뷰 닫기
-                                dismissWebView(webviewController) {
-                                    DispatchQueue.main.async {
-                                        if let topController =
-                                            UIViewController.getTopViewController(),
-                                            topController.view.window != nil
-                                        {
-                                            // 새로운 웹뷰 표시
-                                            let newWebViewController = WebViewController(
-                                                content: .url(url))
-                                            let navigationController =
-                                                UINavigationController(
-                                                    rootViewController: newWebViewController)
-                                            navigationController.modalPresentationStyle =
-                                                .fullScreen
+                                switch SdkConfig.inAppUrlOpenOptions.httpUrlOpenTarget {
+                                case .internalWebView:
+                                    dismissWebView(webviewController) {
+                                        DispatchQueue.main.async {
+                                            if let topController =
+                                                UIViewController.getTopViewController(),
+                                                topController.view.window != nil
+                                            {
+                                                let newWebViewController = WebViewController(
+                                                    content: .url(url))
+                                                let navigationController =
+                                                    UINavigationController(
+                                                        rootViewController: newWebViewController)
+                                                navigationController.modalPresentationStyle =
+                                                    .fullScreen
 
-                                            topController.present(
-                                                navigationController, animated: true,
-                                                completion: nil
-                                            )
-                                        } else {
-                                            Logger.error(
-                                                "INAPP: Top view controller is not in the window hierarchy."
-                                            )
+                                                topController.present(
+                                                    navigationController, animated: true,
+                                                    completion: nil
+                                                )
+                                            } else {
+                                                Logger.error(
+                                                    "INAPP: Top view controller is not in the window hierarchy."
+                                                )
+                                            }
                                         }
                                     }
+                                case .externalBrowser:
+                                    dismissWebView(webviewController) {
+                                        UIApplication.shared.open(url, options: [:])
+                                    }
+                                case .none:
+                                    dismissWebView(webviewController)
                                 }
                             default:
                                 dismissWebView(webviewController) {

--- a/BluxClient/Classes/SdkConfig.swift
+++ b/BluxClient/Classes/SdkConfig.swift
@@ -51,6 +51,25 @@ enum SdkConfig {
         }
     }
 
+    private static var inAppUrlOpenOptionsKey = "bluxInAppUrlOpenOptions"
+    static var inAppUrlOpenOptions: InAppUrlOpenOptions {
+        set {
+            UserDefaults(suiteName: bluxSuiteName)?.set(
+                newValue.httpUrlOpenTarget.rawValue,
+                forKey: inAppUrlOpenOptionsKey
+            )
+        }
+        get {
+            guard let rawValue = UserDefaults(suiteName: bluxSuiteName)?
+                .object(forKey: inAppUrlOpenOptionsKey) as? Int,
+                let target = HttpUrlOpenTarget(rawValue: rawValue)
+            else {
+                return .init()
+            }
+            return InAppUrlOpenOptions(httpUrlOpenTarget: target)
+        }
+    }
+
     /// Save bluxId in user defaults (local storage)
     private static var bluxIdKey = "bluxId"
     static var bluxIdInUserDefaults: String? {

--- a/Tests/BluxClientPublicAPITests/PublicAPISurfaceTests.swift
+++ b/Tests/BluxClientPublicAPITests/PublicAPISurfaceTests.swift
@@ -31,6 +31,8 @@ final class PublicAPISurfaceTests: XCTestCase {
 
         let _: (NotificationUrlOpenOptions) -> Void = BluxClient.setNotificationUrlOpenOptions
 
+        let _: (InAppUrlOpenOptions) -> Void = BluxClient.setInAppUrlOpenOptions
+
         let _: () -> Void = BluxClient.dismissInApp
 
         let _: (@escaping (BluxNotification) -> Void) -> Void = BluxClient.setNotificationClickedHandler(callback:)

--- a/Tests/BluxClientTests/BluxClientTests.swift
+++ b/Tests/BluxClientTests/BluxClientTests.swift
@@ -48,6 +48,20 @@ final class BluxClientTests: XCTestCase {
         XCTAssertEqual(SdkConfig.notificationUrlOpenOptions.httpUrlOpenTarget, .none)
     }
 
+    // MARK: - setInAppUrlOpenOptions
+
+    func testSetInAppUrlOpenOptionsPersists() {
+        BluxClient.setInAppUrlOpenOptions(
+            InAppUrlOpenOptions(httpUrlOpenTarget: .externalBrowser)
+        )
+        XCTAssertEqual(SdkConfig.inAppUrlOpenOptions.httpUrlOpenTarget, .externalBrowser)
+
+        BluxClient.setInAppUrlOpenOptions(
+            InAppUrlOpenOptions(httpUrlOpenTarget: .none)
+        )
+        XCTAssertEqual(SdkConfig.inAppUrlOpenOptions.httpUrlOpenTarget, .none)
+    }
+
     // MARK: - signIn 사전조건
 
     func testSignInFailsFastWhenNoIds() {

--- a/Tests/BluxClientTests/InAppUrlOpenOptionsTests.swift
+++ b/Tests/BluxClientTests/InAppUrlOpenOptionsTests.swift
@@ -1,0 +1,19 @@
+import XCTest
+@testable import BluxClient
+
+final class InAppUrlOpenOptionsTests: XCTestCase {
+    func testDefaultIsInternalWebView() {
+        let options = InAppUrlOpenOptions()
+        XCTAssertEqual(options.httpUrlOpenTarget, .internalWebView)
+    }
+
+    func testInitWithExternalBrowser() {
+        let options = InAppUrlOpenOptions(httpUrlOpenTarget: .externalBrowser)
+        XCTAssertEqual(options.httpUrlOpenTarget, .externalBrowser)
+    }
+
+    func testInitWithNone() {
+        let options = InAppUrlOpenOptions(httpUrlOpenTarget: .none)
+        XCTAssertEqual(options.httpUrlOpenTarget, .none)
+    }
+}

--- a/Tests/BluxClientTests/RNFlutterBridgeContractTests.swift
+++ b/Tests/BluxClientTests/RNFlutterBridgeContractTests.swift
@@ -216,6 +216,19 @@ final class RNFlutterBridgeContractTests: XCTestCase {
         XCTAssertEqual(SdkConfig.notificationUrlOpenOptions.httpUrlOpenTarget, HttpUrlOpenTarget.none)
     }
 
+    func testFlutter_InAppUrlOpenOptionsInitWithAllTargets() {
+        let opts1 = InAppUrlOpenOptions(httpUrlOpenTarget: .internalWebView)
+        let opts2 = InAppUrlOpenOptions(httpUrlOpenTarget: .externalBrowser)
+        let opts3 = InAppUrlOpenOptions(httpUrlOpenTarget: HttpUrlOpenTarget.none)
+
+        BluxClient.setInAppUrlOpenOptions(opts1)
+        XCTAssertEqual(SdkConfig.inAppUrlOpenOptions.httpUrlOpenTarget, .internalWebView)
+        BluxClient.setInAppUrlOpenOptions(opts2)
+        XCTAssertEqual(SdkConfig.inAppUrlOpenOptions.httpUrlOpenTarget, .externalBrowser)
+        BluxClient.setInAppUrlOpenOptions(opts3)
+        XCTAssertEqual(SdkConfig.inAppUrlOpenOptions.httpUrlOpenTarget, HttpUrlOpenTarget.none)
+    }
+
     // MARK: - Flutter: Event chain (BluxFlutterPlugin sendEvent 패턴)
 
     func testFlutter_EventChainWithSetEventProperties() throws {

--- a/Tests/BluxClientTests/SdkConfigTests.swift
+++ b/Tests/BluxClientTests/SdkConfigTests.swift
@@ -4,20 +4,26 @@ import XCTest
 final class SdkConfigTests: XCTestCase {
     private var guardian: SdkStateGuard!
     private var savedNotificationUrlOpenOptions: NotificationUrlOpenOptions!
+    private var savedInAppUrlOpenOptions: InAppUrlOpenOptions!
     // SdkConfig 내부 private key와 동기화 필요 (default 동작 검증을 위해 키 자체를 제거)
     private let notificationUrlOpenOptionsUserDefaultsKey = "bluxNotificationUrlOpenOptions"
+    private let inAppUrlOpenOptionsUserDefaultsKey = "bluxInAppUrlOpenOptions"
 
     override func setUp() {
         super.setUp()
         guardian = SdkStateGuard()
         guardian.clear()
         savedNotificationUrlOpenOptions = SdkConfig.notificationUrlOpenOptions
+        savedInAppUrlOpenOptions = SdkConfig.inAppUrlOpenOptions
         UserDefaults(suiteName: SdkConfig.bluxSuiteName)?
             .removeObject(forKey: notificationUrlOpenOptionsUserDefaultsKey)
+        UserDefaults(suiteName: SdkConfig.bluxSuiteName)?
+            .removeObject(forKey: inAppUrlOpenOptionsUserDefaultsKey)
     }
 
     override func tearDown() {
         SdkConfig.notificationUrlOpenOptions = savedNotificationUrlOpenOptions
+        SdkConfig.inAppUrlOpenOptions = savedInAppUrlOpenOptions
         guardian.restore()
         guardian = nil
         super.tearDown()
@@ -149,5 +155,34 @@ final class SdkConfigTests: XCTestCase {
     func testNotificationUrlOpenOptionsPersistsNoneTarget() {
         SdkConfig.notificationUrlOpenOptions = NotificationUrlOpenOptions(httpUrlOpenTarget: HttpUrlOpenTarget.none)
         XCTAssertEqual(SdkConfig.notificationUrlOpenOptions.httpUrlOpenTarget, HttpUrlOpenTarget.none)
+    }
+
+    // MARK: - InAppUrlOpenOptions persistence
+
+    func testInAppUrlOpenOptionsDefaultIsInternalWebView() {
+        let options = SdkConfig.inAppUrlOpenOptions
+        XCTAssertEqual(options.httpUrlOpenTarget, .internalWebView)
+    }
+
+    func testInAppUrlOpenOptionsRoundTripExternalBrowser() {
+        SdkConfig.inAppUrlOpenOptions = InAppUrlOpenOptions(httpUrlOpenTarget: .externalBrowser)
+        XCTAssertEqual(SdkConfig.inAppUrlOpenOptions.httpUrlOpenTarget, .externalBrowser)
+    }
+
+    func testInAppUrlOpenOptionsRoundTripNone() {
+        SdkConfig.inAppUrlOpenOptions = InAppUrlOpenOptions(httpUrlOpenTarget: .none)
+        XCTAssertEqual(SdkConfig.inAppUrlOpenOptions.httpUrlOpenTarget, .none)
+    }
+
+    func testInAppUrlOpenOptionsPersistsAcrossReads() {
+        SdkConfig.inAppUrlOpenOptions = InAppUrlOpenOptions(httpUrlOpenTarget: .externalBrowser)
+        for _ in 0..<3 {
+            XCTAssertEqual(SdkConfig.inAppUrlOpenOptions.httpUrlOpenTarget, .externalBrowser)
+        }
+    }
+
+    func testInAppUrlOpenOptionsPersistsNoneTarget() {
+        SdkConfig.inAppUrlOpenOptions = InAppUrlOpenOptions(httpUrlOpenTarget: HttpUrlOpenTarget.none)
+        XCTAssertEqual(SdkConfig.inAppUrlOpenOptions.httpUrlOpenTarget, HttpUrlOpenTarget.none)
     }
 }


### PR DESCRIPTION
# 📝 Changes

호스트 앱이 인앱 메시지의 http/https 링크 오픈 동작을 외부에서 제어할 수 있는 public API를 추가했다. 알림용 `setNotificationUrlOpenOptions`와 동일 패턴, 같은 `HttpUrlOpenTarget` enum 재사용.

```swift
BluxClient.setInAppUrlOpenOptions(InAppUrlOpenOptions(httpUrlOpenTarget: .externalBrowser))
```

옵션값 세 가지:

- `.internalWebView` — 기본. SDK 내장 WebView로 표시
- `.externalBrowser` — OS 외부 브라우저로 열기. Universal Links 등록 호스트는 OS가 자기 앱으로 라우팅
- `.none` — SDK가 URL을 열지 않음. 클릭 트래킹은 정상 발사

정책은 http와 https에만 적용된다. 그 외 커스텀 스킴은 기존 `UIApplication.shared.open` 경로 그대로.

옵션값은 인앱 전용 키 `bluxInAppUrlOpenOptions`로 App Group `UserDefaults`에 영속화된다. 알림 키 `bluxNotificationUrlOpenOptions`와 분리되어 있어 콜드 스타트 후에도 마지막 설정값이 유지된다.

# Tests you conducted

신규 단위 테스트 10건 모두 PASS:

- `InAppUrlOpenOptionsTests` (3건) — default, explicit target, `.none`. `NotificationUrlOpenOptionsTests` 미러
- `SdkConfigTests` (5건) — UserDefaults persistence: default, round-trip externalBrowser/none, 다중 read 보존, none target 보존
- `BluxClientTests` (1건) — `setInAppUrlOpenOptions`의 UserDefaults 동기 (externalBrowser → none)
- `RNFlutterBridgeContractTests` (1건) — RN/Flutter wrapper용 시그니처와 모든 `HttpUrlOpenTarget` 처리

`PublicAPISurfaceTests`에는 `setInAppUrlOpenOptions` 함수 reference를 추가해 public 시그니처 회귀를 컴파일 타임에 잡는다. 기존 `NotificationUrlOpenOptions` 관련 테스트도 PASS — 알림 경로 회귀 없음.

CI pre-merge gate `BLUX_STAGE=stg bundle exec pod lib lint BluxClient.podspec --allow-warnings --skip-tests` — Lint OK.

# ⛑ QA Test Cases

- [x] 테스트가 필요 없습니다 (체크하면 QA 라벨이 자동으로 추가되지 않습니다.)

---

Slack: https://teamslack-k7w6420.slack.com/archives/C09THTSL9GD/p1777430373032159