### PR TITLE
ci: pod trunk push 응답을 실제 trunk 상태로 재검증

### DIFF
--- a/.github/actions/cocoapods-publish/action.yml
+++ b/.github/actions/cocoapods-publish/action.yml
@@ -1,0 +1,76 @@
+name: Publish podspec to CocoaPods trunk
+description: |
+  Idempotent push:
+  - 이미 publish된 버전이면 push 자체를 skip
+  - push가 실패해도 trunk에 등록되어 있으면 success로 처리 (응답만 손실된 케이스)
+
+inputs:
+  podspec:
+    description: Path to podspec file
+    required: true
+  pod-name:
+    description: Pod name as listed on CocoaPods trunk
+    required: true
+  tag:
+    description: Version tag being published
+    required: true
+  stage:
+    description: BLUX_STAGE value (stg or prod)
+    required: true
+  trunk-token:
+    description: CocoaPods trunk authentication token
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Check if version already on trunk
+      id: precheck
+      shell: bash
+      env:
+        COCOAPODS_TRUNK_TOKEN: ${{ inputs.trunk-token }}
+        POD: ${{ inputs.pod-name }}
+        TAG: ${{ inputs.tag }}
+      run: |
+        ESCAPED="${TAG//./\\.}"
+        if bundle exec pod trunk info "$POD" 2>/dev/null \
+            | grep -qE "^[[:space:]]+- ${ESCAPED} \("; then
+          echo "Version $TAG is already on trunk. Skipping push."
+          echo "skip=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "skip=false" >> "$GITHUB_OUTPUT"
+        fi
+
+    - name: Push to trunk
+      if: steps.precheck.outputs.skip != 'true'
+      shell: bash
+      env:
+        COCOAPODS_TRUNK_TOKEN: ${{ inputs.trunk-token }}
+        BLUX_STAGE: ${{ inputs.stage }}
+        PODSPEC: ${{ inputs.podspec }}
+        POD: ${{ inputs.pod-name }}
+        TAG: ${{ inputs.tag }}
+      run: |
+        set +e
+        bundle exec pod trunk push "$PODSPEC" --allow-warnings
+        PUSH_EXIT=$?
+        set -e
+
+        if [ "$PUSH_EXIT" -eq 0 ]; then
+          exit 0
+        fi
+
+        # push가 실패로 끝났을 때, trunk가 실제로는 publish를 받았는지 검증.
+        # CDN 반영 지연을 고려해 잠시 대기 후 조회.
+        echo "::warning::pod trunk push reported failure (exit $PUSH_EXIT). Verifying actual trunk state..."
+        sleep 15
+
+        ESCAPED="${TAG//./\\.}"
+        if bundle exec pod trunk info "$POD" 2>/dev/null \
+            | grep -qE "^[[:space:]]+- ${ESCAPED} \("; then
+          echo "Version $TAG is on trunk despite push failure. Treating as success (response lost but publish landed)."
+          exit 0
+        fi
+
+        echo "::error::Version $TAG is not on trunk. Push truly failed."
+        exit "$PUSH_EXIT"

--- a/.github/workflows/release-internal.yml
+++ b/.github/workflows/release-internal.yml
@@ -114,7 +114,10 @@ jobs:
 
       - name: Publish to CocoaPods
         if: steps.tag.outputs.skipped != 'true'
-        env:
-          COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}
-        run: |
-          BLUX_STAGE=stg bundle exec pod trunk push BluxClient.podspec --allow-warnings
+        uses: ./.github/actions/cocoapods-publish
+        with:
+          podspec: BluxClient.podspec
+          pod-name: BluxClient
+          tag: ${{ steps.version.outputs.tag }}
+          stage: stg
+          trunk-token: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}

--- a/.github/workflows/release-prod.yml
+++ b/.github/workflows/release-prod.yml
@@ -147,7 +147,10 @@ jobs:
           BLUX_STAGE=prod bundle exec pod lib lint BluxClient.podspec --allow-warnings --skip-tests
 
       - name: Publish to CocoaPods
-        env:
-          COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}
-        run: |
-          BLUX_STAGE=prod bundle exec pod trunk push BluxClient.podspec --allow-warnings
+        uses: ./.github/actions/cocoapods-publish
+        with:
+          podspec: BluxClient.podspec
+          pod-name: BluxClient
+          tag: ${{ steps.version.outputs.tag }}
+          stage: prod
+          trunk-token: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}


### PR DESCRIPTION
# 📝 Changes

## 무슨 일이 있었나

prod 0.6.14 배포에서 `pod trunk push`가 publish는 정상으로 끝냈는데 trunk 서버가 응답을 깨뜨려서 워크플로우가 빨갛게 떴다. 실제로는 CocoaPods에 0.6.14가 등록되어 있었음 (`pod trunk info BluxClient`로 확인됨).

실패한 워크플로우: https://github.com/zaikorea/Blux-iOS-SDK/actions/runs/25148530819/job/73713483462

이 상태에서 failed job을 단순 re-run하면 trunk가 "이미 등록됨"으로 거부해서 또 빨갛게 뜬다. 사람이 매번 "publish는 됐으니 fail은 무시"라고 판단해야 한다.

## 어떻게 고쳤나

`pod trunk push`의 응답을 그대로 믿지 않고, 명령이 실패해도 `pod trunk info`로 trunk 상태를 직접 조회해서 success/fail을 다시 판정한다.

흐름:

1. **push 전** — trunk에 이 버전이 이미 있나? 있으면 SKIP (success로 종료)
2. **push 시도**
3. **push 성공** → DONE
4. **push 실패** → 15초 대기 후 trunk info 재조회
   - 등록되어 있으면 "응답만 깨진 케이스" → SUCCESS
   - 없으면 진짜 실패 → FAIL

이 로직을 새 composite action [`.github/actions/cocoapods-publish/action.yml`](.github/actions/cocoapods-publish/action.yml) 한 곳에 두고, [`release-prod.yml`](.github/workflows/release-prod.yml) / [`release-internal.yml`](.github/workflows/release-internal.yml) 양쪽에서 호출.

## 다음에 같은 사고가 나면

- 응답 누락이지만 publish가 실제로 됐다면 → 워크플로우는 그대로 success로 떨어짐. 사람 개입 필요 없음.
- 진짜 publish 실패라면 → 평소처럼 fail로 뜨고 사람이 봐야 함.

## 알려진 제한 (이번 PR 스코프 밖)

`release-internal`은 같은 commit으로 재dispatch 시 tag 중복 처리 때문에 publish step 자체를 skip한다. 이번 사고(응답 누락)는 첫 시도에서 새 action이 success로 처리하므로 무관하지만, **다른 종류의 진짜 publish 실패** 후 rerun 시 false success가 가능. 별도 작업으로 분리.

# Tests you conducted

워크플로우 변경이라 lint 외 직접 실행 검증 어려움. 다음 release-internal 자동 trigger(다음 main push)에서 새 action 경로가 정상적으로 구동되는지 확인 예정.

`pod trunk info BluxClient` 출력 형식이 grep 패턴과 매칭되는지 로컬에서 수동 확인 완료 — `^[[:space:]]+- {VERSION} \(` 형태로 등록된 버전이 표시됨.

# ⛑ QA Test Cases

- [x] 테스트가 필요 없습니다 (체크하면 QA 라벨이 자동으로 추가되지 않습니다.)