### PR TITLE
fix: 인앱 배너 이중 표시 race 제거

### DIFF
--- a/BluxClient/Classes/WebViewController.swift
+++ b/BluxClient/Classes/WebViewController.swift
@@ -14,6 +14,7 @@ final class WebViewController: UIViewController, WKNavigationDelegate,
     private var webView: WKWebView!
     private var content: Content
     private let messageHandler = WebViewMessageHandler()
+    private var hasLoadedContent = false
 
     // Content 타입 정의: URL 또는 HTML 문자열
     enum Content {
@@ -130,8 +131,16 @@ final class WebViewController: UIViewController, WKNavigationDelegate,
             navigationController?.navigationBar.barTintColor = .lightGray
         }
         navigationController?.navigationBar.prefersLargeTitles = false
+    }
 
-        // Content에 따라 로드
+    /// HTML 로드를 viewDidAppear까지 지연시켜, present 트랜지션이 끝난 뒤에만 webview가 메시지를
+    /// 보내도록 한다. 배너용 인앱은 webview의 runtime이 즉시 `resize`를 발사하는데, 만약 이 메시지가
+    /// `present` 트랜지션이 끝나기 전에 도착하면 `dismiss(animated: false)`가 무시되어 fullscreen
+    /// WebViewController + BannerWindow가 동시에 보이는 race가 발생한다.
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        guard !hasLoadedContent else { return }
+        hasLoadedContent = true
         loadContent()
     }
 


### PR DESCRIPTION
# 📝 Changes

다이소-Prod에서 인앱 배너가 같은 내용으로 **두 개 겹쳐 보이는 현상** 수정.

## 원인

- `inapp-renderer`가 self-contained HTML로 바뀌면서 webview 로드 직후 거의 즉시 `resize` 메시지를 발사 (이전 Next.js 기반 HTML보다 훨씬 빠름)
- `WebViewController.viewDidLoad`에서 `loadContent()`를 호출하기 때문에, `present(animated: false)` 트랜지션이 끝나기 **전에** resize가 도착하는 경우가 빈번
- `InappService`의 resize 핸들러는 `webviewController.dismiss(animated: false)` 후 `BannerWindow`를 띄우는데, present 트랜지션 진행 중에 호출된 `dismiss`는 iOS가 무시 → fullscreen `WebViewController`가 그대로 남고 `BannerWindow`까지 추가로 표시되어 **이중 표시**

## 수정

- `WebViewController`의 HTML 로드 시점을 `viewDidLoad` → `viewDidAppear`로 이전
- `present` 트랜지션이 완전히 끝난 후에만 webview가 HTML 로드를 시작하므로, 이어지는 `resize` → `dismiss` 흐름이 항상 정상 동작
- `hasLoadedContent` 플래그로 `viewDidAppear` 재호출 시 중복 로드 방지

## 영향 범위

- **banner**: race 해결 (수정 목적)
- **modal / bottomSheet / slide**: resize 자체를 발사하지 않으므로 영향 없음. HTML 로드가 미세하게(~10-50ms) 늦어지지만 `animated: false` present라 사용자 인지 불가
- **customHtml**: `BluxBridge.resize()`가 명시 호출이고 JS 실행은 viewDidAppear 한참 후라 race 발생 불가

# Tests you conducted

- 다이소-Prod와 동일하게 `is_new_inapp_renderer_enabled: true`로 설정한 dev 앱에서 물리 디바이스로 재현 → 수정 후 1개만 표시되는 것 확인 예정

# ⛑ QA Test Cases

- [ ] 테스트가 필요 없습니다 (체크하면 QA 라벨이 자동으로 추가되지 않습니다.)

- 새 renderer가 적용된 앱에서 banner 인앱이 1개만 정상 표시되는지 확인
- modal / bottomSheet / slide 인앱 정상 표시 확인 (시각적 깜빡임 없는지)
- banner 인앱의 클릭/링크 이동/숨기기(days_to_hide) 동작 확인
- customHtml 인앱(있다면) 정상 표시 + `BluxBridge.resize()` 호출 시 BannerWindow 전환 확인