### PR TITLE
feat: 인앱 메시지 클릭 콜백 핸들러 setInAppClickedHandler 추가

### DIFF
--- a/BluxClient/Classes/BluxClient.swift
+++ b/BluxClient/Classes/BluxClient.swift
@@ -415,6 +415,15 @@ struct UpdatePropertiesBody: Codable {
         }
     }
 
+    /// 인앱 메시지의 http/https 링크 클릭을 호스트 앱이 직접 처리하도록 콜백을 등록한다.
+    /// 등록되어 있으면 SDK는 URL 자동 오픈을 skip하고 콜백만 호출한다.
+    @objc public static func setInAppClickedHandler(
+        callback: @escaping (BluxInApp) -> Void
+    ) {
+        EventHandlers.inAppClicked = callback
+        Logger.verbose("InAppClickedHandler has been registered.")
+    }
+
     /// Custom HTML 인앱 메시지에서 BluxBridge.triggerAction() 호출 시 실행될 핸들러를 등록합니다.
     /// 여러 핸들러를 등록할 수 있으며, 등록 순서대로 실행됩니다.
     ///

--- a/BluxClient/Classes/BluxInApp.swift
+++ b/BluxClient/Classes/BluxInApp.swift
@@ -1,0 +1,12 @@
+import Foundation
+
+@objc open class BluxInApp: NSObject {
+    @objc public let id: String
+    @objc public let url: String?
+
+    @objc public init(id: String, url: String?) {
+        self.id = id
+        self.url = url == "" ? nil : url
+        super.init()
+    }
+}

--- a/BluxClient/Classes/EventHandlers.swift
+++ b/BluxClient/Classes/EventHandlers.swift
@@ -7,6 +7,7 @@ enum EventHandlers {
     static var unhandledNotification: BluxNotification?
     static var notificationForegroundWillDisplay: ((NotificationReceivedEvent) -> Void)?
     static var notificationClicked: ((BluxNotification) -> Void)?
+    static var inAppClicked: ((BluxInApp) -> Void)?
     /// Custom HTML 인앱 메시지에서 BluxBridge.triggerAction() 호출 시 실행되는 핸들러 목록
     /// 복수의 핸들러 등록 가능, 등록 순서대로 실행
     static var inAppCustomActionHandlers: [(id: UUID, handler: InAppCustomActionHandler)] = []

--- a/BluxClient/Classes/InappService.swift
+++ b/BluxClient/Classes/InappService.swift
@@ -267,25 +267,31 @@ class InappService {
                                         switch scheme {
                                         case "http", "https":
                                             createInappOpened(notificationId)
-                                            switch SdkConfig.inAppUrlOpenOptions.httpUrlOpenTarget {
-                                            case .internalWebView:
+                                            if let clicked = EventHandlers.inAppClicked {
                                                 dismissBannerWindow {
-                                                    DispatchQueue.main.async {
-                                                        if let topController = UIViewController.getTopViewController(),
-                                                           topController.view.window != nil {
-                                                            let newWebViewController = WebViewController(content: .url(url))
-                                                            let navigationController = UINavigationController(rootViewController: newWebViewController)
-                                                            navigationController.modalPresentationStyle = .fullScreen
-                                                            topController.present(navigationController, animated: true, completion: nil)
+                                                    clicked(BluxInApp(id: notificationId, url: urlString))
+                                                }
+                                            } else {
+                                                switch SdkConfig.inAppUrlOpenOptions.httpUrlOpenTarget {
+                                                case .internalWebView:
+                                                    dismissBannerWindow {
+                                                        DispatchQueue.main.async {
+                                                            if let topController = UIViewController.getTopViewController(),
+                                                               topController.view.window != nil {
+                                                                let newWebViewController = WebViewController(content: .url(url))
+                                                                let navigationController = UINavigationController(rootViewController: newWebViewController)
+                                                                navigationController.modalPresentationStyle = .fullScreen
+                                                                topController.present(navigationController, animated: true, completion: nil)
+                                                            }
                                                         }
                                                     }
+                                                case .externalBrowser:
+                                                    dismissBannerWindow {
+                                                        UIApplication.shared.open(url, options: [:])
+                                                    }
+                                                case .none:
+                                                    dismissBannerWindow()
                                                 }
-                                            case .externalBrowser:
-                                                dismissBannerWindow {
-                                                    UIApplication.shared.open(url, options: [:])
-                                                }
-                                            case .none:
-                                                dismissBannerWindow()
                                             }
                                         default:
                                             dismissBannerWindow {
@@ -359,39 +365,45 @@ class InappService {
                             switch scheme {
                             case "http", "https":
                                 createInappOpened(notificationId)
-                                switch SdkConfig.inAppUrlOpenOptions.httpUrlOpenTarget {
-                                case .internalWebView:
+                                if let clicked = EventHandlers.inAppClicked {
                                     dismissWebView(webviewController) {
-                                        DispatchQueue.main.async {
-                                            if let topController =
-                                                UIViewController.getTopViewController(),
-                                                topController.view.window != nil
-                                            {
-                                                let newWebViewController = WebViewController(
-                                                    content: .url(url))
-                                                let navigationController =
-                                                    UINavigationController(
-                                                        rootViewController: newWebViewController)
-                                                navigationController.modalPresentationStyle =
-                                                    .fullScreen
+                                        clicked(BluxInApp(id: notificationId, url: urlString))
+                                    }
+                                } else {
+                                    switch SdkConfig.inAppUrlOpenOptions.httpUrlOpenTarget {
+                                    case .internalWebView:
+                                        dismissWebView(webviewController) {
+                                            DispatchQueue.main.async {
+                                                if let topController =
+                                                    UIViewController.getTopViewController(),
+                                                    topController.view.window != nil
+                                                {
+                                                    let newWebViewController = WebViewController(
+                                                        content: .url(url))
+                                                    let navigationController =
+                                                        UINavigationController(
+                                                            rootViewController: newWebViewController)
+                                                    navigationController.modalPresentationStyle =
+                                                        .fullScreen
 
-                                                topController.present(
-                                                    navigationController, animated: true,
-                                                    completion: nil
-                                                )
-                                            } else {
-                                                Logger.error(
-                                                    "INAPP: Top view controller is not in the window hierarchy."
-                                                )
+                                                    topController.present(
+                                                        navigationController, animated: true,
+                                                        completion: nil
+                                                    )
+                                                } else {
+                                                    Logger.error(
+                                                        "INAPP: Top view controller is not in the window hierarchy."
+                                                    )
+                                                }
                                             }
                                         }
+                                    case .externalBrowser:
+                                        dismissWebView(webviewController) {
+                                            UIApplication.shared.open(url, options: [:])
+                                        }
+                                    case .none:
+                                        dismissWebView(webviewController)
                                     }
-                                case .externalBrowser:
-                                    dismissWebView(webviewController) {
-                                        UIApplication.shared.open(url, options: [:])
-                                    }
-                                case .none:
-                                    dismissWebView(webviewController)
                                 }
                             default:
                                 dismissWebView(webviewController) {

--- a/Tests/BluxClientPublicAPITests/PublicAPISurfaceTests.swift
+++ b/Tests/BluxClientPublicAPITests/PublicAPISurfaceTests.swift
@@ -37,6 +37,8 @@ final class PublicAPISurfaceTests: XCTestCase {
 
         let _: (@escaping (BluxNotification) -> Void) -> Void = BluxClient.setNotificationClickedHandler(callback:)
 
+        let _: (@escaping (BluxInApp) -> Void) -> Void = BluxClient.setInAppClickedHandler(callback:)
+
         let _: (@escaping (NotificationReceivedEvent) -> Void) -> Void
             = BluxClient.setNotificationForegroundWillDisplayHandler(callback:)
 
@@ -70,6 +72,9 @@ final class PublicAPISurfaceTests: XCTestCase {
 
         // BluxNotification public init
         let _ = BluxNotification(id: "x", body: "y", title: nil, url: nil, imageUrl: nil, data: nil)
+
+        // BluxInApp public init
+        let _ = BluxInApp(id: "x", url: "https://example.com")
 
         // LogLevel cases
         let _: LogLevel = .verbose

--- a/Tests/BluxClientTests/BluxClientTests.swift
+++ b/Tests/BluxClientTests/BluxClientTests.swift
@@ -136,6 +136,36 @@ final class BluxClientTests: XCTestCase {
         XCTAssertNotNil(EventHandlers.notificationForegroundWillDisplay)
     }
 
+    // MARK: - setInAppClickedHandler
+
+    func testSetInAppClickedHandlerStoresHandler() {
+        EventHandlers.inAppClicked = nil
+        defer { EventHandlers.inAppClicked = nil }
+
+        var captured: BluxInApp?
+        BluxClient.setInAppClickedHandler { event in captured = event }
+        XCTAssertNotNil(EventHandlers.inAppClicked)
+
+        let event = BluxInApp(id: "nid_xyz", url: "https://example.com/p/9")
+        EventHandlers.inAppClicked?(event)
+        XCTAssertEqual(captured?.id, "nid_xyz")
+        XCTAssertEqual(captured?.url, "https://example.com/p/9")
+    }
+
+    func testSetInAppClickedHandlerReplacesPrevious() {
+        EventHandlers.inAppClicked = nil
+        defer { EventHandlers.inAppClicked = nil }
+
+        var firstCalled = 0
+        var secondCalled = 0
+        BluxClient.setInAppClickedHandler { _ in firstCalled += 1 }
+        BluxClient.setInAppClickedHandler { _ in secondCalled += 1 }
+
+        EventHandlers.inAppClicked?(BluxInApp(id: "n", url: "https://x"))
+        XCTAssertEqual(firstCalled, 0)
+        XCTAssertEqual(secondCalled, 1)
+    }
+
     // MARK: - addInAppCustomActionHandler
 
     func testAddInAppCustomActionHandlerReturnsUnsubscribeFunction() {

--- a/Tests/BluxClientTests/BluxInAppTests.swift
+++ b/Tests/BluxClientTests/BluxInAppTests.swift
@@ -1,0 +1,21 @@
+import XCTest
+@testable import BluxClient
+
+final class BluxInAppTests: XCTestCase {
+    func testHoldsIdAndUrl() {
+        let event = BluxInApp(id: "nid_1", url: "https://example.com/path")
+        XCTAssertEqual(event.id, "nid_1")
+        XCTAssertEqual(event.url, "https://example.com/path")
+    }
+
+    func testUrlCanBeNil() {
+        let event = BluxInApp(id: "nid_2", url: nil)
+        XCTAssertEqual(event.id, "nid_2")
+        XCTAssertNil(event.url)
+    }
+
+    func testEmptyUrlIsNormalizedToNil() {
+        let event = BluxInApp(id: "nid_3", url: "")
+        XCTAssertNil(event.url, "Empty string url should normalize to nil (mirror of BluxNotification)")
+    }
+}

--- a/Tests/BluxClientTests/EventHandlersTests.swift
+++ b/Tests/BluxClientTests/EventHandlersTests.swift
@@ -18,6 +18,7 @@ final class EventHandlersTests: XCTestCase {
         EventHandlers.unhandledNotification = nil
         EventHandlers.notificationForegroundWillDisplay = nil
         EventHandlers.notificationClicked = nil
+        EventHandlers.inAppClicked = nil
         EventHandlers.inAppCustomActionHandlers = []
     }
 
@@ -41,6 +42,20 @@ final class EventHandlersTests: XCTestCase {
         let n = BluxNotification(id: "x", body: "B", title: nil, url: nil, imageUrl: nil, data: nil)
         EventHandlers.notificationClicked?(n)
         XCTAssertEqual(captured?.id, "x")
+    }
+
+    func testInAppClickedSlotStartsNil() {
+        XCTAssertNil(EventHandlers.inAppClicked)
+    }
+
+    func testInAppClickedSlotStoresClosure() {
+        var captured: BluxInApp?
+        EventHandlers.inAppClicked = { event in captured = event }
+
+        let event = BluxInApp(id: "nid_1", url: "https://example.com/p/1")
+        EventHandlers.inAppClicked?(event)
+        XCTAssertEqual(captured?.id, "nid_1")
+        XCTAssertEqual(captured?.url, "https://example.com/p/1")
     }
 
     // MARK: - inAppCustomActionHandlers

--- a/Tests/BluxClientTests/support/SdkStateGuard.swift
+++ b/Tests/BluxClientTests/support/SdkStateGuard.swift
@@ -38,6 +38,7 @@ final class SdkStateGuard {
         EventHandlers.unhandledNotification = nil
         EventHandlers.notificationClicked = nil
         EventHandlers.notificationForegroundWillDisplay = nil
+        EventHandlers.inAppClicked = nil
         EventHandlers.inAppCustomActionHandlers = []
 
         ColdStartNotificationManager.coldStartNotification = nil
@@ -57,6 +58,7 @@ final class SdkStateGuard {
         EventHandlers.unhandledNotification = nil
         EventHandlers.notificationClicked = nil
         EventHandlers.notificationForegroundWillDisplay = nil
+        EventHandlers.inAppClicked = nil
         EventHandlers.inAppCustomActionHandlers = []
 
         ColdStartNotificationManager.coldStartNotification = nil


### PR DESCRIPTION
# 📝 Changes

호스트 앱이 인앱의 http/https 링크 클릭을 직접 처리하도록 콜백을 등록하는 API.

```swift
BluxClient.setInAppClickedHandler { inApp in
    myRouter.navigate(to: inApp.url)
}
```

- 등록되어 있으면 SDK는 URL 자동 오픈을 skip하고 콜백만 invoke
- 클릭 트래킹(`inapp_opened`)과 인앱 dismiss는 정상 수행
- 미등록 시 기존 `setInAppUrlOpenOptions` 정책 (기본 `.internalWebView`)
- Custom HTML 인앱의 `BluxBridge.triggerAction()` 경로는 영향 없음
- 신규 모델: `@objc BluxInApp(id, url)` — 빈 문자열 url은 nil로 normalize

# Tests you conducted

- 단위 테스트 7건 PASS (`BluxClientTests`, `BluxInAppTests`, `EventHandlersTests`, `PublicAPISurfaceTests`)
- Flutter example E2E: iPhone 16e Simulator (iOS 26.0) — cartadd → 배너 → 클릭 시 정확한 id/url로 콜백, URL 오픈 차단 확인
- `BLUX_STAGE=stg bundle exec pod lib lint BluxClient.podspec --allow-warnings --skip-tests` — Lint OK

# ⛑ QA Test Cases

- [x] 테스트가 필요 없습니다 (체크하면 QA 라벨이 자동으로 추가되지 않습니다.)

---

Slack: https://teamslack-k7w6420.slack.com/archives/C09THTSL9GD/p1778056419197199?thread_ts=1777430373.032159&cid=C09THTSL9GD