### PR TITLE
feat: BluxInApp.toDictionary 추가 (BluxNotification 패턴 일관성)

### DIFF
--- a/BluxClient/Classes/BluxInApp.swift
+++ b/BluxClient/Classes/BluxInApp.swift
@@ -9,4 +9,13 @@ import Foundation
         self.url = url == "" ? nil : url
         super.init()
     }
+
+    public func toDictionary() -> [String: Any?] {
+        let dict: [String: Any?] = [
+            "id": id,
+            "url": url,
+        ]
+
+        return dict
+    }
 }

--- a/Tests/BluxClientTests/BluxInAppTests.swift
+++ b/Tests/BluxClientTests/BluxInAppTests.swift
@@ -18,4 +18,18 @@ final class BluxInAppTests: XCTestCase {
         let event = BluxInApp(id: "nid_3", url: "")
         XCTAssertNil(event.url, "Empty string url should normalize to nil (mirror of BluxNotification)")
     }
+
+    func testToDictionaryExposesIdAndUrl() {
+        let event = BluxInApp(id: "nid_1", url: "https://example.com/path")
+        let dict = event.toDictionary()
+        XCTAssertEqual(dict["id"] as? String, "nid_1")
+        XCTAssertEqual(dict["url"] as? String, "https://example.com/path")
+    }
+
+    func testToDictionaryPreservesNilUrl() {
+        let event = BluxInApp(id: "nid_2", url: nil)
+        let dict = event.toDictionary()
+        XCTAssertEqual(dict["id"] as? String, "nid_2")
+        XCTAssertNil(dict["url"] ?? nil)
+    }
 }


### PR DESCRIPTION
# 📝 Changes

`BluxInApp`에 `toDictionary()`를 추가해 `BluxNotification`과 동일한 패턴을 유지한다. wrapper(Flutter/RN)가 인앱 클릭 핸들러를 채널로 전달할 때 dict shape를 SDK가 결정하도록 일관성 확보.

```swift
let dict = inApp.toDictionary()  // ["id": ..., "url": ...]
```

- `BluxNotification.toDictionary()`와 동일 시그니처/스타일 (`[String: Any?]`)
- `@objc` 미부착 — `[String: Any?]` 반환 타입은 Objective-C에서 직접 사용 불가하나, wrapper는 Swift 경유이므로 영향 없음 (`BluxNotification`도 동일)

# Tests you conducted

- 단위 테스트 2건 추가 PASS: id/url 노출, nil url 보존
- `BLUX_STAGE=stg bundle exec pod lib lint BluxClient.podspec --allow-warnings --skip-tests` — passed validation

# ⛑ QA Test Cases

- [x] 테스트가 필요 없습니다 (체크하면 QA 라벨이 자동으로 추가되지 않습니다.)

---

Slack: https://teamslack-k7w6420.slack.com/archives/C09THTSL9GD/p1778056419197199?thread_ts=1777430373.032159&cid=C09THTSL9GD