### PR TITLE
fix: NSE에 build-time/runtime stage 정합

### DIFF
--- a/BluxClient/Classes/Stage.swift
+++ b/BluxClient/Classes/Stage.swift
@@ -43,8 +43,30 @@ public enum Stage: String, CaseIterable {
         #endif
     }()
 
-    /// 런타임 오버라이드
-    private static var overrideStage: Stage?
+    static let overrideStageKey = "bluxStageOverride"
+
+    private static var overrideStage: Stage? {
+        get {
+            let defaults = UserDefaults(suiteName: SdkConfig.bluxSuiteName)
+            // prod 빌드면 이전 non-prod 빌드의 stale 값을 무시 + cleanup.
+            guard defaultStage != .prod else {
+                defaults?.removeObject(forKey: overrideStageKey)
+                return nil
+            }
+            guard let raw = defaults?.string(forKey: overrideStageKey) else {
+                return nil
+            }
+            return Stage(rawValue: raw)
+        }
+        set {
+            let defaults = UserDefaults(suiteName: SdkConfig.bluxSuiteName)
+            if let newValue = newValue {
+                defaults?.set(newValue.rawValue, forKey: overrideStageKey)
+            } else {
+                defaults?.removeObject(forKey: overrideStageKey)
+            }
+        }
+    }
 
     /// 현재 스테이지 (오버라이드가 있으면 오버라이드, 없으면 빌드 시점 기본값)
     public static var current: Stage {

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,6 +31,7 @@ iOS는 자동 등록 메커니즘이 없어 호스트 앱이 명시적으로 다
 2. **APNs entitlement** + Info.plist `UIBackgroundModes = [remote-notification]`.
 3. **NSE 타겟** + `BluxNotificationServiceExtensionHelper.shared.didReceive` 위임 ([Example/BluxNotificationServiceExtension/NotificationService.swift](Example/BluxNotificationServiceExtension/NotificationService.swift)).
 4. **AppDelegate 위임 4개 메서드** — `didFinishLaunchingWithOptions`에서 `BluxClient.initialize` + `UNUserNotificationCenter.current().delegate = self`, `didRegisterForRemoteNotificationsWithDeviceToken` → `BluxAppDelegate.shared`, `userNotificationCenter(_:didReceive:)` / `(_:willPresent:)` → `BluxNotificationCenter.shared`. swizzling은 의도적으로 안 씀 — 호스트가 자체 delegate 가질 때 chain 깨지는 사고 이력. ([Example/BluxExample/AppDelegate.swift](Example/BluxExample/AppDelegate.swift))
+5. **NSE Info.plist `BluxStage`** — non-prod 분기 빌드 사용 시 NSE Info.plist에도 main 앱과 같은 값 명시 ([Example/BluxNotificationServiceExtension/Info.plist](Example/BluxNotificationServiceExtension/Info.plist)). NSE는 별도 process라 main app의 `Stage.setStage` 호출이 안 보이고, Info.plist 없으면 NSE 내부 `Stage.current`가 default `.prod`로 fallback해 NSE의 `trackReceived` HTTP가 prod API로 향한다.
 
 ## 자주 깨지는 곳 (운영)
 

--- a/Example/BluxExample.xcodeproj/project.pbxproj
+++ b/Example/BluxExample.xcodeproj/project.pbxproj
@@ -58,8 +58,11 @@
 		02501D2E7A12E13D05614279 /* Pods-BluxNotificationServiceExtension.debug-dev.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BluxNotificationServiceExtension.debug-dev.xcconfig"; path = "Target Support Files/Pods-BluxNotificationServiceExtension/Pods-BluxNotificationServiceExtension.debug-dev.xcconfig"; sourceTree = "<group>"; };
 		03F84019D2B5D8F8F15D9186 /* Pods-BluxExample.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BluxExample.release.xcconfig"; path = "Target Support Files/Pods-BluxExample/Pods-BluxExample.release.xcconfig"; sourceTree = "<group>"; };
 		0FACEEF88C0AE07F453B4E7B /* LICENSE */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = LICENSE; path = ../LICENSE; sourceTree = "<group>"; };
+		165FFA2B9A0EF7319CEB1498 /* Release-dev-NSE.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Release-dev-NSE.xcconfig"; path = "Release-dev-NSE.xcconfig"; sourceTree = "<group>"; };
 		22D311105412579A107172F9 /* Pods-BluxNotificationServiceExtension.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BluxNotificationServiceExtension.release.xcconfig"; path = "Target Support Files/Pods-BluxNotificationServiceExtension/Pods-BluxNotificationServiceExtension.release.xcconfig"; sourceTree = "<group>"; };
+		2A6324DAAFB088FCC1572D1C /* Debug-stg-NSE.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Debug-stg-NSE.xcconfig"; path = "Debug-stg-NSE.xcconfig"; sourceTree = "<group>"; };
 		3BA3E804D31BDE9ED5D46F9C /* Pods_BluxExample.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_BluxExample.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		3C19EC6E6D49C4BED7B8F002 /* Release-local-NSE.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Release-local-NSE.xcconfig"; path = "Release-local-NSE.xcconfig"; sourceTree = "<group>"; };
 		479C9F989489650C0A9B0CA7 /* Pods-BluxNotificationServiceExtension.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BluxNotificationServiceExtension.debug.xcconfig"; path = "Target Support Files/Pods-BluxNotificationServiceExtension/Pods-BluxNotificationServiceExtension.debug.xcconfig"; sourceTree = "<group>"; };
 		5112D404AB03AADA31747BC9 /* Pods-BluxExample.debug-prod.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BluxExample.debug-prod.xcconfig"; path = "Target Support Files/Pods-BluxExample/Pods-BluxExample.debug-prod.xcconfig"; sourceTree = "<group>"; };
 		5A4B52BF72214C468F20A09C /* Pods-BluxExample.release-dev.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BluxExample.release-dev.xcconfig"; path = "Target Support Files/Pods-BluxExample/Pods-BluxExample.release-dev.xcconfig"; sourceTree = "<group>"; };
@@ -74,15 +77,19 @@
 		607FACEB1AFB9204008FA782 /* Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Tests.swift; sourceTree = "<group>"; };
 		61D80ABE71CA7617091B696D /* Pods-BluxExample.release-prod.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BluxExample.release-prod.xcconfig"; path = "Target Support Files/Pods-BluxExample/Pods-BluxExample.release-prod.xcconfig"; sourceTree = "<group>"; };
 		6B1AC77452879F547D20FA32 /* Pods-BluxNotificationServiceExtension.debug-stg.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BluxNotificationServiceExtension.debug-stg.xcconfig"; path = "Target Support Files/Pods-BluxNotificationServiceExtension/Pods-BluxNotificationServiceExtension.debug-stg.xcconfig"; sourceTree = "<group>"; };
+		74F100FC8620756DFF334C93 /* Debug-dev-NSE.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Debug-dev-NSE.xcconfig"; path = "Debug-dev-NSE.xcconfig"; sourceTree = "<group>"; };
 		7865891FBC83CB6067A5EE7C /* Pods-BluxNotificationServiceExtension.release-stg.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BluxNotificationServiceExtension.release-stg.xcconfig"; path = "Target Support Files/Pods-BluxNotificationServiceExtension/Pods-BluxNotificationServiceExtension.release-stg.xcconfig"; sourceTree = "<group>"; };
 		78926C502C48FCB800F605C4 /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
 		7E2333B67F4C224F9B47F5C9 /* Pods-BluxExample.debug-local.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BluxExample.debug-local.xcconfig"; path = "Target Support Files/Pods-BluxExample/Pods-BluxExample.debug-local.xcconfig"; sourceTree = "<group>"; };
 		80F639E3D48DBACF91654949 /* Pods-BluxExample.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BluxExample.debug.xcconfig"; path = "Target Support Files/Pods-BluxExample/Pods-BluxExample.debug.xcconfig"; sourceTree = "<group>"; };
 		9D23C329FE92F82717C5E738 /* Pods-BluxNotificationServiceExtension.debug-prod.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BluxNotificationServiceExtension.debug-prod.xcconfig"; path = "Target Support Files/Pods-BluxNotificationServiceExtension/Pods-BluxNotificationServiceExtension.debug-prod.xcconfig"; sourceTree = "<group>"; };
 		A33900889E92ABDB8E50C27E /* Pods-BluxNotificationServiceExtension.debug-local.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BluxNotificationServiceExtension.debug-local.xcconfig"; path = "Target Support Files/Pods-BluxNotificationServiceExtension/Pods-BluxNotificationServiceExtension.debug-local.xcconfig"; sourceTree = "<group>"; };
+		A74649F35857DE40DA531C98 /* Release-stg-NSE.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Release-stg-NSE.xcconfig"; path = "Release-stg-NSE.xcconfig"; sourceTree = "<group>"; };
 		A92C0CAC19F57E83D9DDE5B8 /* Pods-BluxNotificationServiceExtension.release-local.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BluxNotificationServiceExtension.release-local.xcconfig"; path = "Target Support Files/Pods-BluxNotificationServiceExtension/Pods-BluxNotificationServiceExtension.release-local.xcconfig"; sourceTree = "<group>"; };
 		B969707409259452097B72C6 /* Pods_BluxNotificationServiceExtension.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_BluxNotificationServiceExtension.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		B97C959233B8CED618DA3953 /* Pods-BluxExample.release-local.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BluxExample.release-local.xcconfig"; path = "Target Support Files/Pods-BluxExample/Pods-BluxExample.release-local.xcconfig"; sourceTree = "<group>"; };
+		B9FCC328A48CAFA3E3870051 /* Release-prod-NSE.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Release-prod-NSE.xcconfig"; path = "Release-prod-NSE.xcconfig"; sourceTree = "<group>"; };
+		C2F507F1D0032A6193E80E23 /* Debug-prod-NSE.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Debug-prod-NSE.xcconfig"; path = "Debug-prod-NSE.xcconfig"; sourceTree = "<group>"; };
 		CRED00001AFB9204008FA782 /* Credentials.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Credentials.swift; sourceTree = "<group>"; };
 		D6990DEB3C05017510417CDA /* Pods-BluxNotificationServiceExtension.release-dev.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BluxNotificationServiceExtension.release-dev.xcconfig"; path = "Target Support Files/Pods-BluxNotificationServiceExtension/Pods-BluxNotificationServiceExtension.release-dev.xcconfig"; sourceTree = "<group>"; };
 		D93ED8302F0BA62700AB82C7 /* BluxExample.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = BluxExample.entitlements; sourceTree = "<group>"; };
@@ -102,6 +109,7 @@
 		ED88E78D2D0F40A30082EA44 /* Release-dev.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "Release-dev.xcconfig"; sourceTree = "<group>"; };
 		EDDC10E22C22BED800242D14 /* Media.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Media.xcassets; sourceTree = "<group>"; };
 		EDDC10EA2C22C5B100242D14 /* Item.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Item.swift; sourceTree = "<group>"; };
+		F1D16C18AC1CC6782A835994 /* Debug-local-NSE.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Debug-local-NSE.xcconfig"; path = "Debug-local-NSE.xcconfig"; sourceTree = "<group>"; };
 		F602B446B737CC3F883633A5 /* Pods-BluxExample.debug-stg.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BluxExample.debug-stg.xcconfig"; path = "Target Support Files/Pods-BluxExample/Pods-BluxExample.debug-stg.xcconfig"; sourceTree = "<group>"; };
 		F76BAAA8E6F66C176FAEEC93 /* Pods-BluxNotificationServiceExtension.release-prod.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BluxNotificationServiceExtension.release-prod.xcconfig"; path = "Target Support Files/Pods-BluxNotificationServiceExtension/Pods-BluxNotificationServiceExtension.release-prod.xcconfig"; sourceTree = "<group>"; };
 		F92D5B1B30F4198189F6FEE7 /* README.md */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = net.daringfireball.markdown; name = README.md; path = ../README.md; sourceTree = "<group>"; };
@@ -279,6 +287,14 @@
 				ED88E7872D0F40A30082EA44 /* Release-stg.xcconfig */,
 				ED88E7882D0F40A30082EA44 /* Debug-prod.xcconfig */,
 				ED88E7892D0F40A30082EA44 /* Release-prod.xcconfig */,
+				F1D16C18AC1CC6782A835994 /* Debug-local-NSE.xcconfig */,
+				74F100FC8620756DFF334C93 /* Debug-dev-NSE.xcconfig */,
+				2A6324DAAFB088FCC1572D1C /* Debug-stg-NSE.xcconfig */,
+				C2F507F1D0032A6193E80E23 /* Debug-prod-NSE.xcconfig */,
+				3C19EC6E6D49C4BED7B8F002 /* Release-local-NSE.xcconfig */,
+				165FFA2B9A0EF7319CEB1498 /* Release-dev-NSE.xcconfig */,
+				A74649F35857DE40DA531C98 /* Release-stg-NSE.xcconfig */,
+				B9FCC328A48CAFA3E3870051 /* Release-prod-NSE.xcconfig */,
 			);
 			path = Config;
 			sourceTree = "<group>";
@@ -1316,7 +1332,7 @@
 		};
 		ED88E7742C0F40A30082EA44 /* Debug-stg */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 6B1AC77452879F547D20FA32 /* Pods-BluxNotificationServiceExtension.debug-stg.xcconfig */;
+			baseConfigurationReference = 2A6324DAAFB088FCC1572D1C /* Debug-stg-NSE.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
 				CLANG_ANALYZER_NONNULL = YES;
@@ -1359,7 +1375,7 @@
 		};
 		ED88E7752C0F40A30082EA44 /* Release-stg */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 7865891FBC83CB6067A5EE7C /* Pods-BluxNotificationServiceExtension.release-stg.xcconfig */;
+			baseConfigurationReference = A74649F35857DE40DA531C98 /* Release-stg-NSE.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
 				CLANG_ANALYZER_NONNULL = YES;
@@ -1399,7 +1415,7 @@
 		};
 		ED88E7762C0F40A30082EA44 /* Debug-prod */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 9D23C329FE92F82717C5E738 /* Pods-BluxNotificationServiceExtension.debug-prod.xcconfig */;
+			baseConfigurationReference = C2F507F1D0032A6193E80E23 /* Debug-prod-NSE.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
 				CLANG_ANALYZER_NONNULL = YES;
@@ -1442,7 +1458,7 @@
 		};
 		ED88E7772C0F40A30082EA44 /* Release-prod */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = F76BAAA8E6F66C176FAEEC93 /* Pods-BluxNotificationServiceExtension.release-prod.xcconfig */;
+			baseConfigurationReference = B9FCC328A48CAFA3E3870051 /* Release-prod-NSE.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
 				CLANG_ANALYZER_NONNULL = YES;
@@ -1482,7 +1498,7 @@
 		};
 		ED88E7782C0F40A30082EA44 /* Debug-local */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = A33900889E92ABDB8E50C27E /* Pods-BluxNotificationServiceExtension.debug-local.xcconfig */;
+			baseConfigurationReference = F1D16C18AC1CC6782A835994 /* Debug-local-NSE.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
 				CLANG_ANALYZER_NONNULL = YES;
@@ -1525,7 +1541,7 @@
 		};
 		ED88E7792C0F40A30082EA44 /* Release-local */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = A92C0CAC19F57E83D9DDE5B8 /* Pods-BluxNotificationServiceExtension.release-local.xcconfig */;
+			baseConfigurationReference = 3C19EC6E6D49C4BED7B8F002 /* Release-local-NSE.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
 				CLANG_ANALYZER_NONNULL = YES;
@@ -1565,7 +1581,7 @@
 		};
 		ED88E77A2C0F40A30082EA44 /* Debug-dev */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 02501D2E7A12E13D05614279 /* Pods-BluxNotificationServiceExtension.debug-dev.xcconfig */;
+			baseConfigurationReference = 74F100FC8620756DFF334C93 /* Debug-dev-NSE.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
 				CLANG_ANALYZER_NONNULL = YES;
@@ -1608,7 +1624,7 @@
 		};
 		ED88E77B2C0F40A30082EA44 /* Release-dev */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = D6990DEB3C05017510417CDA /* Pods-BluxNotificationServiceExtension.release-dev.xcconfig */;
+			baseConfigurationReference = 165FFA2B9A0EF7319CEB1498 /* Release-dev-NSE.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
 				CLANG_ANALYZER_NONNULL = YES;

--- a/Example/BluxNotificationServiceExtension/Info.plist
+++ b/Example/BluxNotificationServiceExtension/Info.plist
@@ -4,6 +4,8 @@
 <dict>
 	<key>BluxAppGroupName</key>
 	<string>group.ai.blux.example.nativeapp.blux</string>
+	<key>BluxStage</key>
+	<string>$(BLUX_STAGE)</string>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionPointIdentifier</key>

--- a/Example/Config/Debug-dev-NSE.xcconfig
+++ b/Example/Config/Debug-dev-NSE.xcconfig
@@ -1,0 +1,10 @@
+// Debug-dev configuration wrapper for NSE
+// Includes Pods config and shares BLUX_STAGE with the main app target
+
+#include? "Secrets.xcconfig"
+BLUX_STAGE = dev
+
+#include "../BundleVersion.xcconfig"
+#include "../Pods/Target Support Files/Pods-BluxNotificationServiceExtension/Pods-BluxNotificationServiceExtension.debug-dev.xcconfig"
+
+SWIFT_VERSION = 5.0

--- a/Example/Config/Debug-local-NSE.xcconfig
+++ b/Example/Config/Debug-local-NSE.xcconfig
@@ -1,0 +1,10 @@
+// Debug-local configuration wrapper for NSE
+// Includes Pods config and shares BLUX_STAGE with the main app target
+
+#include? "Secrets.xcconfig"
+BLUX_STAGE = local
+
+#include "../BundleVersion.xcconfig"
+#include "../Pods/Target Support Files/Pods-BluxNotificationServiceExtension/Pods-BluxNotificationServiceExtension.debug-local.xcconfig"
+
+SWIFT_VERSION = 5.0

--- a/Example/Config/Debug-prod-NSE.xcconfig
+++ b/Example/Config/Debug-prod-NSE.xcconfig
@@ -1,0 +1,10 @@
+// Debug-prod configuration wrapper for NSE
+// Includes Pods config and shares BLUX_STAGE with the main app target
+
+#include? "Secrets.xcconfig"
+BLUX_STAGE = prod
+
+#include "../BundleVersion.xcconfig"
+#include "../Pods/Target Support Files/Pods-BluxNotificationServiceExtension/Pods-BluxNotificationServiceExtension.debug-prod.xcconfig"
+
+SWIFT_VERSION = 5.0

--- a/Example/Config/Debug-stg-NSE.xcconfig
+++ b/Example/Config/Debug-stg-NSE.xcconfig
@@ -1,0 +1,10 @@
+// Debug-stg configuration wrapper for NSE
+// Includes Pods config and shares BLUX_STAGE with the main app target
+
+#include? "Secrets.xcconfig"
+BLUX_STAGE = stg
+
+#include "../BundleVersion.xcconfig"
+#include "../Pods/Target Support Files/Pods-BluxNotificationServiceExtension/Pods-BluxNotificationServiceExtension.debug-stg.xcconfig"
+
+SWIFT_VERSION = 5.0

--- a/Example/Config/Release-dev-NSE.xcconfig
+++ b/Example/Config/Release-dev-NSE.xcconfig
@@ -1,0 +1,10 @@
+// Release-dev configuration wrapper for NSE
+// Includes Pods config and shares BLUX_STAGE with the main app target
+
+#include? "Secrets.xcconfig"
+BLUX_STAGE = dev
+
+#include "../BundleVersion.xcconfig"
+#include "../Pods/Target Support Files/Pods-BluxNotificationServiceExtension/Pods-BluxNotificationServiceExtension.release-dev.xcconfig"
+
+SWIFT_VERSION = 5.0

--- a/Example/Config/Release-local-NSE.xcconfig
+++ b/Example/Config/Release-local-NSE.xcconfig
@@ -1,0 +1,10 @@
+// Release-local configuration wrapper for NSE
+// Includes Pods config and shares BLUX_STAGE with the main app target
+
+#include? "Secrets.xcconfig"
+BLUX_STAGE = local
+
+#include "../BundleVersion.xcconfig"
+#include "../Pods/Target Support Files/Pods-BluxNotificationServiceExtension/Pods-BluxNotificationServiceExtension.release-local.xcconfig"
+
+SWIFT_VERSION = 5.0

--- a/Example/Config/Release-prod-NSE.xcconfig
+++ b/Example/Config/Release-prod-NSE.xcconfig
@@ -1,0 +1,10 @@
+// Release-prod configuration wrapper for NSE
+// Includes Pods config and shares BLUX_STAGE with the main app target
+
+#include? "Secrets.xcconfig"
+BLUX_STAGE = prod
+
+#include "../BundleVersion.xcconfig"
+#include "../Pods/Target Support Files/Pods-BluxNotificationServiceExtension/Pods-BluxNotificationServiceExtension.release-prod.xcconfig"
+
+SWIFT_VERSION = 5.0

--- a/Example/Config/Release-stg-NSE.xcconfig
+++ b/Example/Config/Release-stg-NSE.xcconfig
@@ -1,0 +1,10 @@
+// Release-stg configuration wrapper for NSE
+// Includes Pods config and shares BLUX_STAGE with the main app target
+
+#include? "Secrets.xcconfig"
+BLUX_STAGE = stg
+
+#include "../BundleVersion.xcconfig"
+#include "../Pods/Target Support Files/Pods-BluxNotificationServiceExtension/Pods-BluxNotificationServiceExtension.release-stg.xcconfig"
+
+SWIFT_VERSION = 5.0

--- a/Tests/BluxClientTests/StageTests.swift
+++ b/Tests/BluxClientTests/StageTests.swift
@@ -81,4 +81,14 @@ final class StageTests: XCTestCase {
         StageSwitcher.resetStage()
         XCTAssertEqual(Stage.current, .prod)
     }
+
+    /// 같은 App Group을 공유한 이전 non-prod 빌드가 남긴 stale override가 prod 빌드의
+    /// Stage.current를 비-prod로 끌어가지 않아야 한다. 키도 호출 시점에 정리된다.
+    func testCurrentIgnoresAndClearsStaleOverrideWhenDefaultIsProd() {
+        let defaults = UserDefaults(suiteName: SdkConfig.bluxSuiteName)
+        defaults?.set("dev", forKey: Stage.overrideStageKey)
+
+        XCTAssertEqual(Stage.current, .prod)
+        XCTAssertNil(defaults?.string(forKey: Stage.overrideStageKey))
+    }
 }

--- a/Tests/BluxClientTests/support/SdkStateGuard.swift
+++ b/Tests/BluxClientTests/support/SdkStateGuard.swift
@@ -43,6 +43,8 @@ final class SdkStateGuard {
 
         ColdStartNotificationManager.coldStartNotification = nil
         ColdStartNotificationManager.reset()
+
+        UserDefaults(suiteName: SdkConfig.bluxSuiteName)?.removeObject(forKey: Stage.overrideStageKey)
     }
 
     func restore() {
@@ -63,5 +65,7 @@ final class SdkStateGuard {
 
         ColdStartNotificationManager.coldStartNotification = nil
         ColdStartNotificationManager.reset()
+
+        UserDefaults(suiteName: SdkConfig.bluxSuiteName)?.removeObject(forKey: Stage.overrideStageKey)
     }
 }


### PR DESCRIPTION
# Changes

NSE는 별도 process라 main app의 build-time `BluxStage`도 runtime `Stage.setStage`도 보이지 않아 dev/stg 빌드에서도 NSE의 `trackReceived`가 prod API로 향했다.

- NSE 전용 xcconfig wrapper 8개 추가 (`Debug/Release` × `local/dev/stg/prod`)
- NSE target base configuration을 wrapper로 변경
- NSE Info.plist에 `BluxStage = $(BLUX_STAGE)` 추가
- `Stage.overrideStage` 저장소를 App Group `UserDefaults`로 이동
- prod 빌드는 stale override 무시 + 키 제거 (regression test)

# Tests

- SPM 테스트 통과
- 실기기 (iPhone 15 Pro, iOS 18.5) Debug-stg 빌드 e2e:
  - **build-time stage**: NSE Info.plist `BluxStage = stg` resolved → stg API push → dev DB `received`
  - **runtime stage cross-process**: main app에서 `setStage(.dev)` → App Group UserDefaults에 저장 → dev API로 register (dev DB `blux_users.updated_at` 갱신 확인) → dev에서 push 발송 → NSE process가 같은 UserDefaults에서 `.dev` 읽음 → dev API로 `trackReceived` → dev DB `notifications.status = received` (lag 6.2초)

# ⛑ QA Test Cases

- [x] 테스트가 필요 없습니다 (체크하면 QA 라벨이 자동으로 추가되지 않습니다.)
