### PR TITLE
fix: NSE 이미지 첨부 안정성 개선

### DIFF
--- a/BluxClient/Classes/BluxNotificationServiceExtension.swift
+++ b/BluxClient/Classes/BluxNotificationServiceExtension.swift
@@ -16,6 +16,8 @@ open class BluxNotificationServiceExtension: UNNotificationServiceExtension {
 @objc public class BluxNotificationServiceExtensionHelper: NSObject {
     @objc public static let shared = BluxNotificationServiceExtensionHelper()
 
+    private static let imageDownloadTimeout: TimeInterval = 10
+
     // A closure for delivering mutated notification content to the system
     var contentHandler: ((UNNotificationContent) -> Void)?
     var bestAttemptContent: UNMutableNotificationContent?
@@ -50,27 +52,9 @@ open class BluxNotificationServiceExtension: UNNotificationServiceExtension {
             return
         }
 
-        // Download image from imageUrl and attach to the notification
-        let task = URLSession.shared.downloadTask(with: attachmentUrl) { downloadedUrl, _, error in
-            if let _ = error {
-                contentHandler(bestAttemptContent)
-                return
-            }
-
-            if let downloadedUrl = downloadedUrl,
-               let attachment = try? UNNotificationAttachment(
-                   identifier: "Blux_notification_attachment",
-                   url: downloadedUrl,
-                   options: [UNNotificationAttachmentOptionsTypeHintKey: kUTTypePNG]
-               )
-            {
-                bestAttemptContent.attachments = [attachment]
-            }
-
+        attachImage(from: attachmentUrl, to: bestAttemptContent) {
             contentHandler(bestAttemptContent)
         }
-
-        task.resume()
     }
 
     // Called just before when the extension is terminated by the system
@@ -86,6 +70,41 @@ open class BluxNotificationServiceExtension: UNNotificationServiceExtension {
         }
 
         return false
+    }
+
+    private func attachImage(from url: URL, to content: UNMutableNotificationContent, completion: @escaping () -> Void) {
+        let config = URLSessionConfiguration.default
+        config.timeoutIntervalForRequest = Self.imageDownloadTimeout
+        config.timeoutIntervalForResource = Self.imageDownloadTimeout
+        let session = URLSession(configuration: config)
+
+        let task = session.downloadTask(with: url) { downloadedUrl, _, error in
+            defer { completion() }
+
+            if error != nil { return }
+            guard let downloadedUrl = downloadedUrl else { return }
+
+            // URLSession 임시 파일은 completion handler return 후 시스템이 삭제 가능하므로,
+            // contentHandler 호출 시점까지 살아남는 stable URL로 옮긴 뒤 attachment를 만든다.
+            let stableUrl = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+            do {
+                try FileManager.default.moveItem(at: downloadedUrl, to: stableUrl)
+            } catch {
+                return
+            }
+
+            if let attachment = try? UNNotificationAttachment(
+                identifier: "Blux_notification_attachment",
+                url: stableUrl,
+                options: [UNNotificationAttachmentOptionsTypeHintKey: kUTTypePNG]
+            ) {
+                content.attachments = [attachment]
+            } else {
+                // attachment 생성 실패면 시스템이 file을 own하지 않으므로 직접 정리.
+                try? FileManager.default.removeItem(at: stableUrl)
+            }
+        }
+        task.resume()
     }
 }
 

--- a/Tests/BluxClientTests/BluxNotificationServiceExtensionTests.swift
+++ b/Tests/BluxClientTests/BluxNotificationServiceExtensionTests.swift
@@ -1,0 +1,49 @@
+import XCTest
+import UserNotifications
+@testable import BluxClient
+
+final class BluxNotificationServiceExtensionTests: XCTestCase {
+    private var guardian: SdkStateGuard!
+
+    override func setUp() {
+        super.setUp()
+        guardian = SdkStateGuard()
+        guardian.clear()
+    }
+
+    override func tearDown() {
+        guardian.restore()
+        guardian = nil
+        super.tearDown()
+    }
+
+    func testDidReceiveDeliversContentOnceForNonBluxPush() {
+        let content = UNMutableNotificationContent()
+        content.userInfo = ["foo": "bar"]
+        let request = UNNotificationRequest(identifier: "non-blux", content: content, trigger: nil)
+
+        let exp = expectation(description: "contentHandler invoked")
+        exp.assertForOverFulfill = true
+        BluxNotificationServiceExtensionHelper.shared.didReceive(request) { _ in
+            exp.fulfill()
+        }
+        wait(for: [exp], timeout: 1.0)
+    }
+
+    func testDidReceiveDeliversContentOnceForBluxPushWithoutClientId() {
+        let content = UNMutableNotificationContent()
+        content.userInfo = [
+            "isBlux": true,
+            "notificationId": "abc",
+            "aps": ["alert": ["body": "hi"]],
+        ]
+        let request = UNNotificationRequest(identifier: "blux", content: content, trigger: nil)
+
+        let exp = expectation(description: "contentHandler invoked exactly once")
+        exp.assertForOverFulfill = true
+        BluxNotificationServiceExtensionHelper.shared.didReceive(request) { _ in
+            exp.fulfill()
+        }
+        wait(for: [exp], timeout: 5.0)
+    }
+}


### PR DESCRIPTION
# Changes

main의 image download는 `URLSession.shared` 기본 timeout (request 60s, resource 7일)이라 서버 hang / 매우 느린 네트워크 edge case에서 NSE 30초 한도 안에 다른 fire-and-forget 요청(`trackReceived`)이 잘릴 위험.

또 URLSession download callback의 임시 파일은 callback return 후 시스템이 삭제할 수 있어 attachment 표시 실패 가능.

- 이미지 전용 `URLSessionConfiguration` + timeout 10초
- 임시 파일을 stable URL로 move 후 `UNNotificationAttachment` 생성, 생성 실패 시 직접 cleanup

# Tests

- SPM 테스트 통과 (non-Blux push early return + Blux push contentHandler 1회)
- 실기기 (iPhone 15 Pro, iOS 18.5) e2e 9 시나리오 — 모두 dev DB `status=received` 보장 (lag ≤1.1초)

| 시나리오 | imageUrl | lag |
|---|---|---|
| 정상 이미지 (작은/중간) | picsum 600×400, 2400×2400 PNG | 0.39–0.67s |
| **timeout fallback** | httpbin.org/delay/15 (15s 응답) | **0.61s** |
| 빈 응답 | httpbin.org/bytes/0 | 0.51s |
| 404 / DNS 실패 | nonexistent path / .invalid host | 0.42–1.08s |

# ⛑ QA Test Cases

- [x] 테스트가 필요 없습니다 (체크하면 QA 라벨이 자동으로 추가되지 않습니다.)
