### PR TITLE
fix: foreground notification suppress 시 completionHandler 자동 호출

### DIFF
--- a/BluxClient/Classes/BluxNotificationCenter.swift
+++ b/BluxClient/Classes/BluxNotificationCenter.swift
@@ -102,7 +102,7 @@ public class BluxNotificationCenter: NSObject, UNUserNotificationCenterDelegate 
             }
 
             let event = NotificationReceivedEvent(
-                UIApplication.shared, notification: bluxNotification,
+                notification: bluxNotification,
                 completionHandler: completionHandler
             )
 

--- a/BluxClient/Classes/NotificationReceivedEvent.swift
+++ b/BluxClient/Classes/NotificationReceivedEvent.swift
@@ -4,13 +4,20 @@ import UserNotifications
 
 @objc open class NotificationReceivedEvent: NSObject {
     @objc public var notification: BluxNotification
-    private var application: UIApplication
-    private var completionHandler: (UNNotificationPresentationOptions) -> Void
 
-    init(_ application: UIApplication, notification: BluxNotification, completionHandler: @escaping (UNNotificationPresentationOptions) -> Void) {
-        self.application = application
+    /// completionHandler 호출 직후 한 번 호출. wrapper가 자기 dict cleanup에 사용.
+    @objc public var onComplete: (() -> Void)?
+
+    private var completionHandler: ((UNNotificationPresentationOptions) -> Void)?
+    private var fallbackWorkItem: DispatchWorkItem?
+
+    private static let fallbackTimeout: TimeInterval = 20
+
+    init(notification: BluxNotification, completionHandler: @escaping (UNNotificationPresentationOptions) -> Void) {
         self.notification = notification
         self.completionHandler = completionHandler
+        super.init()
+        scheduleFallback()
     }
 
     @objc public func toDictionary() -> [String: Any] {
@@ -21,6 +28,44 @@ import UserNotifications
 
     @objc public func display() {
         Logger.verbose("Notification received: \(notification)")
-        completionHandler([.alert, .sound])
+        complete(with: [.alert, .sound])
+    }
+
+    /// 시스템 알림을 표시하지 않음 (인앱 UI로만 처리하는 경우 등).
+    /// display()/suppress() 둘 다 미호출이면 fallback timeout 후 자동 suppress.
+    @objc public func suppress() {
+        Logger.verbose("Notification suppressed: \(notification.id)")
+        complete(with: [])
+    }
+
+    private func scheduleFallback() {
+        // strong capture: wrapper가 event ref를 일찍 놓아도 fallback이 발화해 completionHandler를 호출한다.
+        let workItem = DispatchWorkItem { [self] in
+            Logger.verbose("NotificationReceivedEvent fallback timeout: suppressing notification \(notification.id)")
+            complete(with: [])
+        }
+        fallbackWorkItem = workItem
+        DispatchQueue.main.asyncAfter(deadline: .now() + Self.fallbackTimeout, execute: workItem)
+    }
+
+    // display/suppress/fallback 동시 진입 시 completionHandler 중복 호출 방지 + dispatch 대기 중 self release로 인한 미호출 방지.
+    private func complete(with options: UNNotificationPresentationOptions) {
+        if Thread.isMainThread {
+            finalize(with: options)
+        } else {
+            DispatchQueue.main.async { [self] in
+                finalize(with: options)
+            }
+        }
+    }
+
+    private func finalize(with options: UNNotificationPresentationOptions) {
+        guard let handler = completionHandler else { return }
+        completionHandler = nil
+        fallbackWorkItem?.cancel()
+        fallbackWorkItem = nil
+        handler(options)
+        onComplete?()
+        onComplete = nil
     }
 }

--- a/Tests/BluxClientTests/NotificationReceivedEventTests.swift
+++ b/Tests/BluxClientTests/NotificationReceivedEventTests.swift
@@ -6,13 +6,13 @@ import UserNotifications
 final class NotificationReceivedEventTests: XCTestCase {
     func testInitAssignsNotification() {
         let notif = BluxNotification(id: "n", body: "B", title: nil, url: nil, imageUrl: nil, data: nil)
-        let event = NotificationReceivedEvent(UIApplication.shared, notification: notif) { _ in }
+        let event = NotificationReceivedEvent(notification: notif) { _ in }
         XCTAssertEqual(event.notification.id, "n")
     }
 
     func testToDictionaryWrapsNotification() {
         let notif = BluxNotification(id: "n", body: "B", title: "T", url: nil, imageUrl: nil, data: nil)
-        let event = NotificationReceivedEvent(UIApplication.shared, notification: notif) { _ in }
+        let event = NotificationReceivedEvent(notification: notif) { _ in }
         let dict = event.toDictionary()
         XCTAssertNotNil(dict["notification"])
         let inner = dict["notification"] as? [String: Any]
@@ -27,7 +27,7 @@ final class NotificationReceivedEventTests: XCTestCase {
         exp.assertForOverFulfill = true
 
         let notif = BluxNotification(id: "x", body: "B", title: nil, url: nil, imageUrl: nil, data: nil)
-        let event = NotificationReceivedEvent(UIApplication.shared, notification: notif) { options in
+        let event = NotificationReceivedEvent(notification: notif) { options in
             captured = options
             exp.fulfill()
         }
@@ -38,6 +38,43 @@ final class NotificationReceivedEventTests: XCTestCase {
         XCTAssertEqual(captured, [.alert, .sound])
     }
 
+    func testSuppressInvokesCompletionWithEmptyOptions() {
+        var captured: UNNotificationPresentationOptions?
+        let exp = expectation(description: "completion called with empty options")
+        let notif = BluxNotification(id: "x", body: "B", title: nil, url: nil, imageUrl: nil, data: nil)
+        let event = NotificationReceivedEvent(notification: notif) { options in
+            captured = options
+            exp.fulfill()
+        }
+        event.suppress()
+        wait(for: [exp], timeout: 2.0)
+        XCTAssertEqual(captured, [])
+    }
+
+    func testRepeatedCallsInvokeCompletionOnlyOnce() {
+        let exp = expectation(description: "completion called exactly once")
+        exp.expectedFulfillmentCount = 1
+        exp.assertForOverFulfill = true
+        let notif = BluxNotification(id: "x", body: "B", title: nil, url: nil, imageUrl: nil, data: nil)
+        let event = NotificationReceivedEvent(notification: notif) { _ in
+            exp.fulfill()
+        }
+        event.display()
+        event.display()
+        event.suppress()
+        wait(for: [exp], timeout: 2.0)
+    }
+
+    func testOnCompleteFiresAfterCompletion() {
+        let cExp = expectation(description: "completion")
+        let oExp = expectation(description: "onComplete")
+        let notif = BluxNotification(id: "x", body: "B", title: nil, url: nil, imageUrl: nil, data: nil)
+        let event = NotificationReceivedEvent(notification: notif) { _ in cExp.fulfill() }
+        event.onComplete = { oExp.fulfill() }
+        event.display()
+        wait(for: [cExp, oExp], timeout: 2.0, enforceOrder: true)
+    }
+
     func testDisplayDoesNotRequireClientId() {
         let savedClientId = SdkConfig.clientIdInUserDefaults
         defer { SdkConfig.clientIdInUserDefaults = savedClientId }
@@ -45,7 +82,7 @@ final class NotificationReceivedEventTests: XCTestCase {
 
         let exp = expectation(description: "no crash")
         let notif = BluxNotification(id: "x", body: "B", title: nil, url: nil, imageUrl: nil, data: nil)
-        let event = NotificationReceivedEvent(UIApplication.shared, notification: notif) { _ in exp.fulfill() }
+        let event = NotificationReceivedEvent(notification: notif) { _ in exp.fulfill() }
         event.display()
         wait(for: [exp], timeout: 2.0)
     }

--- a/Tests/BluxClientTests/RNFlutterBridgeContractTests.swift
+++ b/Tests/BluxClientTests/RNFlutterBridgeContractTests.swift
@@ -15,7 +15,7 @@ import UIKit
 /// - `UserProperties(phoneNumber:..., gender:...)` 모든 옵셔널 init
 /// - `UserProperties.Gender(rawValue:)` ("male"/"female")
 /// - `HttpUrlOpenTarget` 멤버 (`.internalWebView`, `.externalBrowser`, `.none`)
-/// - `NotificationReceivedEvent.toDictionary()` / `display()`
+/// - `NotificationReceivedEvent.toDictionary()` / `display()` / `suppress()` / `onComplete`
 /// - `BluxNotification.toDictionary()`
 final class RNFlutterBridgeContractTests: XCTestCase {
     private var guardian: SdkStateGuard!


### PR DESCRIPTION
# 📝 Changes

호스트가 인앱 UI로만 처리하려고 `event.display()`를 호출하지 않을 때 willPresent의 completionHandler가 outstanding 상태로 남고 RN/Flutter wrapper의 dict에 event가 누적되는 문제를 fix.

- `NotificationReceivedEvent.suppress()` 추가 — 호스트가 표시하지 않겠다고 명시할 때 호출, 빈 옵션 `[]`으로 즉시 호출
- fallback timer (20s) — `display()`/`suppress()` 둘 다 미호출이면 빈 옵션으로 자동 호출
- `onComplete` 콜백 노출 — completionHandler 호출 직후 1회 호출. wrapper(RN/Flutter)가 자체 dict cleanup에 사용
- `complete()`를 main runloop에 직렬화 + dispatch closure에서 self strong capture — `display`/`suppress`/`fallback` 동시 진입 시 중복 호출, dispatch 대기 중 event release로 인한 미호출 모두 방지
- 미사용 `application` 프로퍼티 제거

## Apple 공식 문서 참고

- [`userNotificationCenter(_:willPresent:withCompletionHandler:)`](https://developer.apple.com/documentation/usernotifications/unusernotificationcenterdelegate/usernotificationcenter(_:willpresent:withcompletionhandler:)) — completionHandler는 "Always execute this block at some point". **delegate 미구현 시 시스템 default = `UNNotificationPresentationOptionNone`(빈 옵션)** → 우리 fallback default와 일치
- [`UNNotificationPresentationOptions`](https://developer.apple.com/documentation/usernotifications/unnotificationpresentationoptions) — 빈 옵션 `[]`은 모든 표시(banner/sound/badge/list) 비활성화
- [`UNNotificationServiceExtension.didReceive`](https://developer.apple.com/documentation/usernotifications/unnotificationserviceextension/didreceive(_:withcontenthandler:)) — "limited amount of time (**no more than 30 seconds**)". willPresent에는 timeout 명시 X. 우리 fallback 20s는 이 30s보다 짧게 잡은 안전 margin

# Tests you conducted

- 단위 테스트 `Tests/BluxClientTests/NotificationReceivedEventTests.swift` 7/7 통과
  - 신규: `testSuppressInvokesCompletionWithEmptyOptions`, `testRepeatedCallsInvokeCompletionOnlyOnce` (race idempotency), `testOnCompleteFiresAfterCompletion`
  - 전체 `BluxClientTests`: 427/427 통과
- E2E (iPhone 17 Pro 시뮬레이터 + `xcrun simctl push`, Example 앱에 임시 handler 추가)
  - `display`: 시스템 banner 표시 ✅
  - `suppress`: 시스템 banner 미표시 ✅
  - `ignore` (둘 다 미호출): 즉시·22초 후 모두 banner 미표시 (fallback 작동) ✅

# ⛑ QA Test Cases

- [x] 테스트가 필요 없습니다 (체크하면 QA 라벨이 자동으로 추가되지 않습니다.)

# 📌 Follow-up

- RN/Flutter wrapper에서 `pendingNotificationForegroundWillDisplayEvents`에 저장하는 시점에 `event.onComplete = { [weak self] in self?.dict.removeValue(forKey: id) }` 연결 필요 (별도 PR)