### PR TITLE
fix: 커스텀 스킴 URL 클릭 시에도 inapp_opened 추적

### DIFF
--- a/BluxClient/Classes/InappService.swift
+++ b/BluxClient/Classes/InappService.swift
@@ -264,9 +264,9 @@ class InappService {
                                     if let urlString = linkData["url"] as? String,
                                        let url = URL(string: urlString),
                                        let scheme = url.scheme {
+                                        createInappOpened(notificationId)
                                         switch scheme {
                                         case "http", "https":
-                                            createInappOpened(notificationId)
                                             if let clicked = EventHandlers.inAppClicked {
                                                 dismissBannerWindow {
                                                     clicked(BluxInApp(id: notificationId, url: urlString))
@@ -362,9 +362,9 @@ class InappService {
                            let url = URL(string: urlString),
                            let scheme = url.scheme
                         {
+                            createInappOpened(notificationId)
                             switch scheme {
                             case "http", "https":
-                                createInappOpened(notificationId)
                                 if let clicked = EventHandlers.inAppClicked {
                                     dismissWebView(webviewController) {
                                         clicked(BluxInApp(id: notificationId, url: urlString))


### PR DESCRIPTION
# 📝 Changes

iOS SDK의 link 메시지 핸들러가 URL 스킴과 무관하게 `inapp_opened` CRM 이벤트를 발생시키도록 수정.

- 변경 전: `http`/`https` URL일 때만 `createInappOpened` 호출 → `hago://`, `hiver://` 같은 커스텀 스킴 클릭 시 추적 누락
- 변경 후: URL 유효성 확인(`scheme` 존재) 후 항상 `createInappOpened` 호출 → Android SDK `onOpenUrl`이 finally 블록에서 항상 `createInAppOpened` 호출하는 것과 일관된 동작
- Modal + Banner 양쪽 link 핸들러에 동일 fix 적용

## 배경

Custom HTML 인앱 메시지에서 이미지 클릭 시 `link` 메시지를 통해 외부 URL로 이동하는 경우, URL이 커스텀 스킴이면 iOS에서만 `inapp_opened` 이벤트가 누락됨. 하고하우스(`hago://`), 패션플러스(`faple://`), 브랜디(`hiverapplication://`) 등 다수 고객사가 영향.

- 패션플러스 사례: iOS 1,550 noti / 0 inapp_opened (실 데이터)
- 하고하우스 사례: 우회안(link 패턴) 테스트 시 iOS만 0건 확인 (Android/웹은 정상)

# Tests you conducted

- Modal/Banner 양쪽 link 핸들러의 모든 URL 스킴 분기 확인
- Android SDK 0.5.27 `onOpenUrl` 동작과 일치하도록 정합