### PR TITLE
ci: release-prod 워크플로우 멱등성 확보

### DIFF
--- a/.github/workflows/release-prod.yml
+++ b/.github/workflows/release-prod.yml
@@ -77,9 +77,16 @@ jobs:
         id: tag_state
         run: |
           TAG="${{ steps.version.outputs.tag }}"
-          git fetch --tags origin --force --quiet || true
+          git fetch --tags origin --force --quiet
           if git rev-parse "refs/tags/$TAG" >/dev/null 2>&1; then
-            echo "Tag $TAG already exists — resuming from publish step."
+            # 태그가 가리키는 commit의 sdkVersion이 의도와 일치하는지 검증.
+            # 수동 태그 생성 / 잘못된 commit으로의 force-update 같은 운영 룰 위반 차단.
+            TAG_SDK_VERSION=$(git show "tags/$TAG:BluxClient/Classes/SdkConfig.swift" | ruby -ne 'if $_ =~ /sdkVersion\s*=\s*"([^"]+)"/; puts $1; exit; end')
+            if [ "$TAG_SDK_VERSION" != "$TAG" ]; then
+              echo "Error: Tag $TAG points to a commit with sdkVersion '$TAG_SDK_VERSION', expected '$TAG'."
+              exit 1
+            fi
+            echo "Tag $TAG already exists and matches expected sdkVersion — resuming from publish step."
             echo "exists=true" >> "$GITHUB_OUTPUT"
           else
             echo "exists=false" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/release-prod.yml
+++ b/.github/workflows/release-prod.yml
@@ -73,12 +73,16 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Check duplicate tag
+      - name: Check tag state
+        id: tag_state
         run: |
           TAG="${{ steps.version.outputs.tag }}"
+          git fetch --tags origin --force --quiet || true
           if git rev-parse "refs/tags/$TAG" >/dev/null 2>&1; then
-            echo "Error: Tag $TAG already exists."
-            exit 1
+            echo "Tag $TAG already exists — resuming from publish step."
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Setup Xcode
@@ -111,6 +115,7 @@ jobs:
           bundle exec pod --version
 
       - name: Update sdkVersion
+        if: steps.tag_state.outputs.exists != 'true'
         run: |
           TAG="${{ steps.version.outputs.tag }}"
           SDK_CONFIG_PATH="BluxClient/Classes/SdkConfig.swift"
@@ -126,6 +131,7 @@ jobs:
           echo "Updated sdkVersion: $UPDATED"
 
       - name: Commit version bump
+        if: steps.tag_state.outputs.exists != 'true'
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
@@ -136,11 +142,16 @@ jobs:
           git push origin HEAD
 
       - name: Create and push tag
+        if: steps.tag_state.outputs.exists != 'true'
         run: |
           TAG="${{ steps.version.outputs.tag }}"
           git tag "$TAG"
           git push origin "$TAG"
           echo "Created and pushed tag: $TAG"
+
+      - name: Checkout existing tag for republish
+        if: steps.tag_state.outputs.exists == 'true'
+        run: git checkout "tags/${{ steps.version.outputs.tag }}"
 
       - name: Lint podspec
         run: |


### PR DESCRIPTION
# 📝 Changes

`release-prod.yml`을 멱등(idempotent)하게 수정. 태그 + version bump commit이 이미 존재하면 publish 단계부터 재개 가능.

## 1. 멱등성

- `Check duplicate tag` → `Check tag state`로 교체. 태그 존재 여부를 `exists` output으로 노출 (fail 대신).
- `Update sdkVersion` / `Commit version bump` / `Create and push tag` 세 단계에 `if: exists != 'true'` 가드 추가.
- `Checkout existing tag for republish` 단계 추가 — 태그가 이미 있으면 그 시점으로 체크아웃해 podspec lint/publish.

## 2. Tag-resume hardening

`exists=true` 분기가 태그 이름만 보고 무조건 publish하는 걸 막기 위해:

- 태그 commit의 `BluxClient/Classes/SdkConfig.swift`에서 `sdkVersion`을 읽어 의도한 태그 값과 일치하는지 검증. 불일치 시 즉시 fail. 수동 태그 생성 / 잘못된 commit으로의 force-update 같은 운영 룰 위반이 prod publish로 흘러가는 경로 차단.
- `git fetch --tags ... || true`의 `|| true` 제거. fetch 실패가 `exists=false` 오판 → version bump 경로 진입 → `git push origin "$TAG"` reject로 이어지는 시나리오 방지.

## 배경

0.6.20 prod 배포 시 ([Actions run](https://github.com/zaikorea/Blux-iOS-SDK/actions/runs/26558308905)) **CocoaPods trunk publish가 GitHub commit API timeout**으로 실패. 다른 모든 단계는 성공 — 태그 `0.6.20` push 완료, `SdkConfig.swift` 갱신 완료, podspec lint 통과. 그러나 워크플로우가 멱등하지 않아 `Re-run failed jobs`로 재실행하면 `Check duplicate tag` 단계에서 `Tag 0.6.20 already exists.` 에러로 즉시 종료 — publish 단계까지 도달 불가.

이번 사고에서는 `release/0.6.20` 브랜치에 같은 패치를 임시 적용하여 dispatch ref를 그 브랜치로 두고 publish만 재실행하는 우회로 복구. 본 PR은 같은 패치를 main에 반영해 다음번 사고에서는 `Re-run failed jobs` 한 번으로 회복 가능하게 한다.

CocoaPods trunk → GitHub Specs repo commit 경로의 timeout은 CocoaPods 인프라 측 일시 장애로 추정. 우리쪽에서 통제 불가하지만, 워크플로우 멱등성 확보로 사후 회복 비용을 0에 가깝게 줄인다.

# Tests you conducted

- `release/0.6.20` 브랜치에서 멱등성 패치 적용 후 [재실행](https://github.com/zaikorea/Blux-iOS-SDK/actions/runs/26559033956) → `Update sdkVersion` / `Commit version bump` / `Create and push tag` 모두 skipped, `Checkout existing tag for republish` + `Lint podspec` + `Publish to CocoaPods` 정상 실행 확인 (CocoaPods 인프라 회복 후 publish 성공, BluxClient 0.6.20 trunk 등록).
- 신규 배포 (태그 미존재 케이스)에서는 `exists=false` → 기존 동작 그대로.
- Tag-resume 검증 로직은 정상 케이스에서 통과 (`TAG_SDK_VERSION == TAG`), 비정상 케이스(stale 태그)는 실제 발생 시 즉시 fail.