### PR TITLE
fix: BluxBridge.resize() right 미반영 및 safe-area inset 미적용 수정

### DIFF
--- a/BluxClient/Classes/BannerWindow.swift
+++ b/BluxClient/Classes/BannerWindow.swift
@@ -126,32 +126,13 @@ final class BannerWindow: UIWindow {
         
     }
     
-    /// Custom HTML 절대 위치 지정 (safe area 적용 안 함)
+    /// Custom HTML 절대 위치 지정
     func updateLayout(options: [String: Any]) {
-        let screenBounds = UIScreen.main.bounds
-
-        let width = parseNumber(options["width"]) ?? screenBounds.width
-        let height = parseNumber(options["height"]) ?? screenBounds.height
-
-        let x: CGFloat
-        if let left = parseNumber(options["left"]) {
-            x = left
-        } else if let right = parseNumber(options["right"]) {
-            x = screenBounds.width - width - right
-        } else {
-            x = (screenBounds.width - width) / 2
-        }
-
-        let y: CGFloat
-        if let top = parseNumber(options["top"]) {
-            y = top
-        } else if let bottom = parseNumber(options["bottom"]) {
-            y = screenBounds.height - height - bottom
-        } else {
-            y = 0
-        }
-
-        let newFrame = CGRect(x: x, y: y, width: width, height: height)
+        let newFrame = BannerWindow.absoluteFrame(
+            options: options,
+            screenBounds: UIScreen.main.bounds,
+            safeAreaInsets: getSafeAreaInsets()
+        )
 
         if isHidden {
             frame = newFrame
@@ -169,7 +150,50 @@ final class BannerWindow: UIWindow {
         }
     }
 
-    private func parseNumber(_ value: Any?) -> CGFloat? {
+    /// Absolute Position Mode의 frame 계산. safe area 안쪽을 기준 영역으로 삼고,
+    /// width/height 미지정 시 기준 영역에서 해당 축 마진을 뺀 값으로 자동 계산한다.
+    static func absoluteFrame(
+        options: [String: Any],
+        screenBounds: CGRect,
+        safeAreaInsets: UIEdgeInsets
+    ) -> CGRect {
+        let contentX = safeAreaInsets.left
+        let contentY = safeAreaInsets.top
+        let contentWidth = screenBounds.width - safeAreaInsets.left - safeAreaInsets.right
+        let contentHeight = screenBounds.height - safeAreaInsets.top - safeAreaInsets.bottom
+
+        let left = parseNumber(options["left"])
+        let right = parseNumber(options["right"])
+        let top = parseNumber(options["top"])
+        let bottom = parseNumber(options["bottom"])
+
+        let width = parseNumber(options["width"])
+            ?? max(0, contentWidth - (left ?? 0) - (right ?? 0))
+        let height = parseNumber(options["height"])
+            ?? max(0, contentHeight - (top ?? 0) - (bottom ?? 0))
+
+        let x: CGFloat
+        if let left = left {
+            x = contentX + left
+        } else if let right = right {
+            x = contentX + contentWidth - width - right
+        } else {
+            x = contentX + (contentWidth - width) / 2
+        }
+
+        let y: CGFloat
+        if let top = top {
+            y = contentY + top
+        } else if let bottom = bottom {
+            y = contentY + contentHeight - height - bottom
+        } else {
+            y = contentY
+        }
+
+        return CGRect(x: x, y: y, width: width, height: height)
+    }
+
+    private static func parseNumber(_ value: Any?) -> CGFloat? {
         if let v = value as? CGFloat { return v }
         if let v = value as? Int { return CGFloat(v) }
         if let v = value as? Double { return CGFloat(v) }

--- a/BluxClient/Classes/BannerWindow.swift
+++ b/BluxClient/Classes/BannerWindow.swift
@@ -92,7 +92,7 @@ final class BannerWindow: UIWindow {
     func updateLayout(height: CGFloat, location: String) {
         currentLocation = location
         
-        let screenBounds = UIScreen.main.bounds
+        let screenBounds = currentScreenBounds()
         let safeAreaInsets = getSafeAreaInsets()
         
         let bannerWidth = min(screenBounds.width * 0.9, BannerWindow.bannerMaxWidth)
@@ -130,7 +130,7 @@ final class BannerWindow: UIWindow {
     func updateLayout(options: [String: Any]) {
         let newFrame = BannerWindow.absoluteFrame(
             options: options,
-            screenBounds: UIScreen.main.bounds,
+            screenBounds: currentScreenBounds(),
             safeAreaInsets: getSafeAreaInsets()
         )
 
@@ -200,12 +200,25 @@ final class BannerWindow: UIWindow {
         return nil
     }
 
+    /// 자기 자신은 frame이 배너 크기라 inset이 0에 가까우므로 host window에서 읽는다
     private func getSafeAreaInsets() -> UIEdgeInsets {
         if #available(iOS 13.0, *) {
-            return windowScene?.windows.first?.safeAreaInsets ?? .zero
+            return windowScene?.windows
+                .first(where: { !($0 is BannerWindow) && !$0.isHidden })?
+                .safeAreaInsets ?? .zero
         } else {
-            return UIApplication.shared.keyWindow?.safeAreaInsets ?? .zero
+            return UIApplication.shared.windows
+                .first(where: { !($0 is BannerWindow) && !$0.isHidden })?
+                .safeAreaInsets ?? .zero
         }
+    }
+
+    /// inset과 같은 scene 좌표계의 bounds — iPad Split View 등 scene < 물리 화면 대응
+    private func currentScreenBounds() -> CGRect {
+        if #available(iOS 13.0, *), let scene = windowScene {
+            return scene.coordinateSpace.bounds
+        }
+        return UIScreen.main.bounds
     }
     
     /// 배너 닫기

--- a/Tests/BluxClientTests/BannerWindowTests.swift
+++ b/Tests/BluxClientTests/BannerWindowTests.swift
@@ -1,0 +1,71 @@
+import XCTest
+@testable import BluxClient
+
+final class BannerWindowTests: XCTestCase {
+    // notch 59pt + 홈 인디케이터 34pt 기준
+    private let screen = CGRect(x: 0, y: 0, width: 393, height: 852)
+    private let insets = UIEdgeInsets(top: 59, left: 0, bottom: 34, right: 0)
+
+    private func frame(_ options: [String: Any]) -> CGRect {
+        BannerWindow.absoluteFrame(
+            options: options,
+            screenBounds: screen,
+            safeAreaInsets: insets
+        )
+    }
+
+    func testWidthAutoCalculatedFromLeftAndRight() {
+        let f = frame(["height": 70, "bottom": 16, "left": 16, "right": 67])
+        XCTAssertEqual(f.origin.x, 16)
+        XCTAssertEqual(f.width, 393 - 16 - 67)
+    }
+
+    func testBottomRespectsSafeAreaInset() {
+        let f = frame(["width": 200, "height": 70, "bottom": 16])
+        XCTAssertEqual(f.maxY, 852 - 34 - 16)
+    }
+
+    func testTopRespectsSafeAreaInset() {
+        let f = frame(["width": 200, "height": 60, "top": 20])
+        XCTAssertEqual(f.origin.y, 59 + 20)
+    }
+
+    func testHeightAutoCalculatedFromTopAndBottom() {
+        let f = frame(["width": 200, "top": 100, "bottom": 100])
+        XCTAssertEqual(f.height, (852 - 59 - 34) - 100 - 100)
+        XCTAssertEqual(f.origin.y, 59 + 100)
+    }
+
+    func testTopTakesPrecedenceWhenHeightGiven() {
+        let f = frame(["width": 200, "height": 70, "top": 10, "bottom": 99])
+        XCTAssertEqual(f.origin.y, 59 + 10)
+        XCTAssertEqual(f.height, 70)
+    }
+
+    func testRightOnlyPositionsFromRightEdge() {
+        let f = frame(["width": 320, "height": 60, "top": 20, "right": 20])
+        XCTAssertEqual(f.maxX, 393 - 20)
+    }
+
+    func testCentersHorizontallyWithoutLeftRight() {
+        let f = frame(["width": 200, "height": 64, "bottom": 80])
+        XCTAssertEqual(f.midX, 393 / 2)
+    }
+
+    func testDefaultsToSafeAreaBounds() {
+        let f = frame([:])
+        XCTAssertEqual(f, CGRect(x: 0, y: 59, width: 393, height: 852 - 59 - 34))
+    }
+
+    func testSizeClampedToZeroWhenMarginsExceedScreen() {
+        let f = frame(["left": 300, "right": 300, "height": 50, "bottom": 0])
+        XCTAssertEqual(f.width, 0)
+    }
+
+    // WKScriptMessage body의 숫자는 NSNumber(Double)로 들어올 수 있다.
+    func testParsesDoubleValues() {
+        let f = frame(["width": 320.5, "height": 60.0, "left": 16.5, "top": 0])
+        XCTAssertEqual(f.width, 320.5)
+        XCTAssertEqual(f.origin.x, 16.5)
+    }
+}

--- a/Tests/BluxClientTests/BannerWindowTests.swift
+++ b/Tests/BluxClientTests/BannerWindowTests.swift
@@ -62,6 +62,17 @@ final class BannerWindowTests: XCTestCase {
         XCTAssertEqual(f.width, 0)
     }
 
+    func testLandscapeInsetsShiftHorizontalFrame() {
+        let f = BannerWindow.absoluteFrame(
+            options: ["height": 70, "bottom": 16, "left": 16, "right": 67],
+            screenBounds: CGRect(x: 0, y: 0, width: 852, height: 393),
+            safeAreaInsets: UIEdgeInsets(top: 0, left: 59, bottom: 21, right: 59)
+        )
+        XCTAssertEqual(f.origin.x, 59 + 16)
+        XCTAssertEqual(f.width, (852 - 59 - 59) - 16 - 67)
+        XCTAssertEqual(f.maxY, 393 - 21 - 16)
+    }
+
     // WKScriptMessage body의 숫자는 NSNumber(Double)로 들어올 수 있다.
     func testParsesDoubleValues() {
         let f = frame(["width": 320.5, "height": 60.0, "left": 16.5, "top": 0])


### PR DESCRIPTION
# 📝 Changes

커스텀 HTML 인앱에서 BluxBridge.resize()를 절대 위치 모드로 쓸 때 iOS만 Android와 다르게 동작하던 문제 두 개를 고칩니다 ([BLX-611](https://app.notion.com/p/BLX-611-iOS-SDK-BluxBridge-resize-Absolute-Position-Mode-right-safe-area-inset-37d7a8baf18881f286ccc1023f118c2f), 카시나 보고).

**무엇이 문제였나**

- left와 right를 같이 줘도 right가 무시됐습니다. Android는 "너비 = 화면 너비 − left − right"로 자동 계산하는데 iOS에는 그 로직이 없었습니다.
- bottom: 16을 줘도 홈 인디케이터 영역(34pt)을 무시하고 물리 화면 맨 아래를 기준으로 배치돼서, 배너가 홈 인디케이터와 겹쳤습니다.

**어떻게 고쳤나**

1. 좌표 기준을 물리 화면에서 safe area 안쪽으로 바꾸고 width/height를 안 주면 남는 공간으로 자동 계산하게 했습니다. Android(fitsSystemWindows 컨테이너 + MATCH_PARENT/margin)와 같은 결과가 나오는지 소스 대조로 확인했습니다.
2. 계산에 쓰는 화면 크기와 safe area 값을 같은 곳(windowScene)에서 읽도록 정리했습니다. 기존에는 화면 크기는 물리 화면에서, inset은 아무 window에서나 읽었습니다. 그래서 iPad Split View에서 어긋날 수 있었고, 두 번째 resize부터는 배너가 자기 자신의 inset(0에 가까움)을 읽어 보정이 조용히 사라질 수 있었습니다.
3. frame 계산을 BannerWindow.absoluteFrame(options:screenBounds:safeAreaInsets:) 순수 함수로 분리하고 단위 테스트를 붙였습니다.

**⚠️ 배포 전 알아둘 것 — 기존 동작이 바뀝니다**

지금까지 문서와 CS 답변은 "절대 위치 모드에서는 safe area가 자동 적용되지 않으니 직접 여백을 더하라"고 안내했습니다. 그 안내대로 보정값을 넣어둔 HTML은 이번 업데이트 후 여백이 두 번 적용됩니다.

- prod DB를 전수 조사해 보니 절대 위치 모드를 쓰는 곳은 카시나-Dev 앱 2건이 전부입니다. 둘 다 env(safe-area-inset-bottom) 합산 코드가 남아 있어서, SDK 업데이트를 안내할 때 HTML에서 safe-area 합산을 빼라는 내용을 함께 보내야 합니다.
- docs.blux.ai의 safe-area 안내 문구도 반대로 고쳐야 합니다.
- 이번에 안 고친 것: 회전 시 재배치(재계산 트리거 없음), left/right 둘 다 없을 때 수평 정렬(iOS는 중앙, Android는 왼쪽 — 기존 동작 유지).

# Tests you conducted

- 단위 테스트 438개 전부 통과. BannerWindowTests 11케이스 추가 — 카시나 케이스, width/height 자동 계산, top/left 우선 규칙, 가로 모드 inset, 0 클램프 등.
- 시뮬레이터 E2E: stg 서버 + dev DB에 test_mode 인앱을 만들어 실제 경로(이벤트 전송 → 인앱 수신 → 모달 → resize → 배너 전환)로 띄우고, 스크린샷 픽셀을 측정해 확인했습니다.
  - {height:70, bottom:16, left:16, right:67} 호출 → 좌 16pt / 우 67pt / 너비 319pt(=402−16−67 자동 계산) / 홈 인디케이터 위 16pt. 전부 기대값과 일치.
  - 같은 인앱에서 height만 70→140으로 재호출 → 하단 기준선 고정, 이중 보정과 위치 점프 없음.

# ⛑ QA Test Cases

- [x] 테스트가 필요 없습니다 (체크하면 QA 라벨이 자동으로 추가되지 않습니다.)