### PR TITLE
fix: WebView 브릿지 이벤트 속성 보존

### DIFF
--- a/BluxClient/Classes/BluxWebSdkBridge.swift
+++ b/BluxClient/Classes/BluxWebSdkBridge.swift
@@ -172,13 +172,13 @@ private extension BluxWebSdkBridge {
             return
         }
 
-        let events = requests.compactMap { buildEvent(from: $0) }
+        let events = buildEvents(from: requests)
         if !events.isEmpty {
             BluxClient.sendRequestData(events)
         }
     }
 
-    func buildEvent(from dict: [String: Any]) -> Event? {
+    func buildEvent(from dict: [String: Any], requestIndex: Int) -> Event? {
         guard let eventType = dict["event_type"] as? String, !eventType.isEmpty else {
             return nil
         }
@@ -189,10 +189,16 @@ private extension BluxWebSdkBridge {
             event.capturedAt = capturedAt
         }
 
-        if let propsDict = dict["event_properties"] as? [String: Any] {
-            if let props: EventProperties = decode(propsDict) {
-                event.setEventProperties(props)
+        if let rawProperties = dict["event_properties"] {
+            guard let propsDict = rawProperties as? [String: Any],
+                  let data = try? JSONSerialization.data(withJSONObject: propsDict),
+                  let props = try? JSONDecoder().decode(EventProperties.self, from: data)
+            else {
+                logInvalidEventProperties(index: requestIndex, eventType: eventType)
+                return nil
             }
+
+            event.setEventProperties(props)
         }
 
         if let customDict = dict["custom_event_properties"] as? [String: Any] {
@@ -206,8 +212,19 @@ private extension BluxWebSdkBridge {
         return event
     }
 
-    func decode<T: Decodable>(_ dict: [String: Any]) -> T? {
-        guard let data = try? JSONSerialization.data(withJSONObject: dict) else { return nil }
-        return try? JSONDecoder().decode(T.self, from: data)
+    func logInvalidEventProperties(index: Int, eventType: String) {
+        Logger.error(
+            "BluxWebSdkBridge.sendEvent: invalid event_properties"
+                + " index=\(index) event_type=\(eventType)"
+        )
+    }
+}
+
+@available(iOSApplicationExtension, unavailable)
+extension BluxWebSdkBridge {
+    func buildEvents(from requests: [[String: Any]]) -> [Event] {
+        requests.enumerated().compactMap { index, request in
+            buildEvent(from: request, requestIndex: index)
+        }
     }
 }

--- a/BluxClient/Classes/request/events/AddOrderEvent.swift
+++ b/BluxClient/Classes/request/events/AddOrderEvent.swift
@@ -35,6 +35,17 @@ public class AddOrderEvent: EventRequest {
             self.quantity = quantity
             self.customEventProperties = customEventProperties
         }
+
+        public required init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            id = try container.decode(String.self, forKey: .id)
+            price = try container.decode(Double.self, forKey: .price)
+            quantity = try container.decodeIfPresent(Int.self, forKey: .quantity) ?? 1
+            customEventProperties = try container.decodeIfPresent(
+                [String: CustomEventValue].self,
+                forKey: .customEventProperties
+            )
+        }
     }
 
     public class Builder {

--- a/BluxClient/Classes/request/events/Event.swift
+++ b/BluxClient/Classes/request/events/Event.swift
@@ -1,5 +1,15 @@
 import Foundation
 
+public struct EventTracking: Codable, Equatable {
+    public let id: String
+    public let type: String
+
+    public init(id: String, type: String) {
+        self.id = id
+        self.type = type
+    }
+}
+
 public class EventProperties: Codable {
     public var itemId: String?
     public var section: String?
@@ -14,6 +24,8 @@ public class EventProperties: Codable {
     public var orderAmount: Double?
     public var paidAmount: Double?
     public var items: [AddOrderEvent.Item]?
+    public var searchQuery: String?
+    public var tracking: EventTracking?
 
     enum CodingKeys: String,
         CodingKey
@@ -31,6 +43,8 @@ public class EventProperties: Codable {
         case orderAmount = "order_amount"
         case paidAmount = "paid_amount"
         case items
+        case searchQuery = "search_query"
+        case tracking
     }
 }
 

--- a/Tests/BluxClientPublicAPITests/PublicAPISurfaceTests.swift
+++ b/Tests/BluxClientPublicAPITests/PublicAPISurfaceTests.swift
@@ -46,7 +46,7 @@ final class PublicAPISurfaceTests: XCTestCase {
             = BluxClient.addInAppCustomActionHandler(callback:)
     }
 
-    func testPublicTypeMembersCompile() {
+    func testPublicTypeMembersCompile() throws {
         // Event public init과 mutable capturedAt
         let event = Event(eventType: "x")
         event.capturedAt = "2025-01-01T00:00:00.000Z"
@@ -59,7 +59,15 @@ final class PublicAPISurfaceTests: XCTestCase {
         // EventProperties는 wrapper SDK에서 JSONDecoder로만 생성하므로 직접 init() 검증은 하지 않는다.
         // (현재 EventProperties는 명시적 public init이 없어 wrapper 모듈에서 직접 init 불가.
         //  Codable witness를 통한 디코딩만 가능.)
-        let _ = try? JSONDecoder().decode(EventProperties.self, from: Data("{}".utf8))
+        let properties = try JSONDecoder().decode(EventProperties.self, from: Data("{}".utf8))
+        let _: (String, String) -> EventTracking = EventTracking.init(id:type:)
+        let tracking = EventTracking(id: "tracking-1", type: "recommendation")
+        let _: String = tracking.id
+        let _: String = tracking.type
+        properties.searchQuery = "shoes"
+        properties.tracking = tracking
+        let _: String? = properties.searchQuery
+        let _: EventTracking? = properties.tracking
 
         // UserProperties는 public init으로 wrapper SDK가 직접 생성한다 (Flutter 패턴).
         let _ = UserProperties()

--- a/Tests/BluxClientTests/BluxWebSdkBridgeTests.swift
+++ b/Tests/BluxClientTests/BluxWebSdkBridgeTests.swift
@@ -320,6 +320,118 @@ final class BluxWebSdkBridgeTests: XCTestCase {
         bridge.handle(scriptMessageBody: body)
     }
 
+    func testBuildEventsPreservesSearchQueryAndTracking() throws {
+        let events = bridge.buildEvents(from: [[
+            "event_type": "search",
+            "event_properties": [
+                "search_query": "running shoes",
+                "tracking": [
+                    "id": "tracking-1",
+                    "type": "recommendation"
+                ]
+            ]
+        ]])
+
+        let event = try XCTUnwrap(events.first)
+        XCTAssertEqual(events.count, 1)
+        XCTAssertEqual(event.eventProperties.searchQuery, "running shoes")
+        XCTAssertEqual(
+            event.eventProperties.tracking,
+            EventTracking(id: "tracking-1", type: "recommendation")
+        )
+
+        let data = try JSONEncoder().encode(event.eventProperties)
+        let encoded = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: data) as? [String: Any]
+        )
+        XCTAssertEqual(encoded["search_query"] as? String, "running shoes")
+        let tracking = try XCTUnwrap(encoded["tracking"] as? [String: Any])
+        XCTAssertEqual(tracking["id"] as? String, "tracking-1")
+        XCTAssertEqual(tracking["type"] as? String, "recommendation")
+    }
+
+    func testBuildEventsPreservesOrderAndDefaultsMissingQuantity() throws {
+        let events = bridge.buildEvents(from: [[
+            "event_type": "order",
+            "event_properties": [
+                "order_id": "order-1",
+                "order_amount": 120.0,
+                "paid_amount": 100.0,
+                "items": [
+                    ["id": "item-1", "price": 40.0, "quantity": 3],
+                    [
+                        "id": "item-2",
+                        "price": 80.0,
+                        "custom_event_properties": ["color": "blue"]
+                    ]
+                ]
+            ]
+        ]])
+
+        let event = try XCTUnwrap(events.first)
+        XCTAssertEqual(event.eventProperties.orderId, "order-1")
+        XCTAssertEqual(event.eventProperties.orderAmount, 120)
+        XCTAssertEqual(event.eventProperties.paidAmount, 100)
+
+        let items = try XCTUnwrap(event.eventProperties.items)
+        XCTAssertEqual(items.count, 2)
+        XCTAssertEqual(items[0].id, "item-1")
+        XCTAssertEqual(items[0].price, 40)
+        XCTAssertEqual(items[0].quantity, 3)
+        XCTAssertEqual(items[1].id, "item-2")
+        XCTAssertEqual(items[1].price, 80)
+        XCTAssertEqual(items[1].quantity, 1)
+        guard case .string("blue")? = items[1].customEventProperties?["color"] else {
+            XCTFail("item custom property was not preserved")
+            return
+        }
+
+        let data = try JSONEncoder().encode(event.eventProperties)
+        let encodedProperties = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: data) as? [String: Any]
+        )
+        let encodedItems = try XCTUnwrap(encodedProperties["items"] as? [[String: Any]])
+        XCTAssertEqual(encodedItems[0]["quantity"] as? Int, 3)
+        XCTAssertEqual(encodedItems[1]["quantity"] as? Int, 1)
+    }
+
+    func testBuildEventsDropsMalformedEventProperties() {
+        let events = bridge.buildEvents(from: [
+            [
+                "event_type": "order",
+                "event_properties": "not-an-object"
+            ],
+            [
+                "event_type": "order",
+                "event_properties": [
+                    "items": [["id": "item-1", "price": "invalid"]]
+                ]
+            ]
+        ])
+
+        XCTAssertTrue(events.isEmpty)
+    }
+
+    func testBuildEventsKeepsValidRequestInMixedBatch() throws {
+        let events = bridge.buildEvents(from: [
+            [
+                "event_type": "order",
+                "event_properties": [
+                    "items": [["id": "item-1", "price": "invalid"]]
+                ]
+            ],
+            [
+                "event_type": "search",
+                "event_properties": ["search_query": "valid query"]
+            ]
+        ])
+
+        let event = try XCTUnwrap(events.first)
+        XCTAssertEqual(events.count, 1)
+        XCTAssertEqual(event.eventType, "search")
+        XCTAssertEqual(event.eventProperties.searchQuery, "valid query")
+    }
+
     // MARK: - Web SDK full contract simulation
 
     /// IosBridge.postMessage가 실제로 만드는 JSON 형태를 그대로 재현.

--- a/Tests/BluxClientTests/EventPropertiesTests.swift
+++ b/Tests/BluxClientTests/EventPropertiesTests.swift
@@ -20,6 +20,8 @@ final class EventPropertiesTests: XCTestCase {
         XCTAssertNil(props.orderAmount)
         XCTAssertNil(props.paidAmount)
         XCTAssertNil(props.items)
+        XCTAssertNil(props.searchQuery)
+        XCTAssertNil(props.tracking)
     }
 
     func testSnakeCaseEncoding() throws {
@@ -31,6 +33,8 @@ final class EventPropertiesTests: XCTestCase {
         props.prevPage = "pp"
         props.orderAmount = 1
         props.paidAmount = 2
+        props.searchQuery = "shoes"
+        props.tracking = EventTracking(id: "tracking-1", type: "recommendation")
 
         let data = try encoder.encode(props)
         let dict = try JSONSerialization.jsonObject(with: data) as! [String: Any]
@@ -42,6 +46,10 @@ final class EventPropertiesTests: XCTestCase {
         XCTAssertEqual(dict["prev_page"] as? String, "pp")
         XCTAssertEqual(dict["order_amount"] as? Double, 1)
         XCTAssertEqual(dict["paid_amount"] as? Double, 2)
+        XCTAssertEqual(dict["search_query"] as? String, "shoes")
+        let tracking = try XCTUnwrap(dict["tracking"] as? [String: Any])
+        XCTAssertEqual(tracking["id"] as? String, "tracking-1")
+        XCTAssertEqual(tracking["type"] as? String, "recommendation")
     }
 
     func testItemsEncodingShape() throws {
@@ -87,5 +95,51 @@ final class EventPropertiesTests: XCTestCase {
         XCTAssertEqual(decoded.itemId, "id")
         XCTAssertEqual(decoded.price, 1.5)
         XCTAssertEqual(decoded.position, 7)
+    }
+
+    func testCodingKeyContractRoundTrip() throws {
+        let expectedKeys: Set<String> = [
+            "item_id",
+            "section",
+            "prev_section",
+            "recommendation_id",
+            "price",
+            "order_id",
+            "rating",
+            "prev_page",
+            "page",
+            "position",
+            "order_amount",
+            "paid_amount",
+            "items",
+            "search_query",
+            "tracking"
+        ]
+        let fixture: [String: Any] = [
+            "item_id": "item-1",
+            "section": "featured",
+            "prev_section": "home",
+            "recommendation_id": "recommendation-1",
+            "price": 10.0,
+            "order_id": "order-1",
+            "rating": 5.0,
+            "prev_page": "landing",
+            "page": "detail",
+            "position": 1.0,
+            "order_amount": 10.0,
+            "paid_amount": 9.0,
+            "items": [["id": "item-1", "price": 10.0, "quantity": 1]],
+            "search_query": "shoes",
+            "tracking": ["id": "tracking-1", "type": "recommendation"]
+        ]
+
+        let input = try JSONSerialization.data(withJSONObject: fixture)
+        let properties = try decoder.decode(EventProperties.self, from: input)
+        let output = try encoder.encode(properties)
+        let encoded = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: output) as? [String: Any]
+        )
+
+        XCTAssertEqual(Set(encoded.keys), expectedKeys)
     }
 }

--- a/Tests/BluxClientTests/RNFlutterBridgeContractTests.swift
+++ b/Tests/BluxClientTests/RNFlutterBridgeContractTests.swift
@@ -76,7 +76,12 @@ final class RNFlutterBridgeContractTests: XCTestCase {
             "event_properties": [
                 "page": "home",
                 "prev_page": "splash",
-                "section": "hero"
+                "section": "hero",
+                "search_query": "running shoes",
+                "tracking": [
+                    "id": "tracking-1",
+                    "type": "recommendation"
+                ]
             ],
             "custom_event_properties": [
                 "scroll_depth": 0.5,
@@ -127,6 +132,11 @@ final class RNFlutterBridgeContractTests: XCTestCase {
         XCTAssertEqual(event.eventProperties.page, "home")
         XCTAssertEqual(event.eventProperties.prevSection, nil)
         XCTAssertEqual(event.eventProperties.section, "hero")
+        XCTAssertEqual(event.eventProperties.searchQuery, "running shoes")
+        XCTAssertEqual(
+            event.eventProperties.tracking,
+            EventTracking(id: "tracking-1", type: "recommendation")
+        )
         if case .double(let d)? = event.customEventProperties?["scroll_depth"] {
             XCTAssertEqual(d, 0.5, accuracy: 0.001)
         } else { XCTFail() }
@@ -237,7 +247,12 @@ final class RNFlutterBridgeContractTests: XCTestCase {
             "event_properties": [
                 "order_id": "O-1",
                 "order_amount": 100.0,
-                "paid_amount": 90.0
+                "paid_amount": 90.0,
+                "search_query": "checkout",
+                "tracking": [
+                    "id": "tracking-2",
+                    "type": "campaign"
+                ]
             ]
         ]
 
@@ -255,6 +270,11 @@ final class RNFlutterBridgeContractTests: XCTestCase {
         XCTAssertEqual(event.eventProperties.orderId, "O-1")
         XCTAssertEqual(event.eventProperties.orderAmount, 100)
         XCTAssertEqual(event.eventProperties.paidAmount, 90)
+        XCTAssertEqual(event.eventProperties.searchQuery, "checkout")
+        XCTAssertEqual(
+            event.eventProperties.tracking,
+            EventTracking(id: "tracking-2", type: "campaign")
+        )
     }
 
     func testFlutter_EventPropertiesDecodeFromEmptyDict() throws {


### PR DESCRIPTION
# 📝 Changes

## 문제

iOS 네이티브 앱의 WKWebView에서 Web SDK가 보낸 이벤트를 `BluxWebSdkBridge`가 네이티브 `Event` 모델로 변환할 때, 두 가지 방식으로 속성이 유실된다.

첫째, `EventProperties`에 `search_query`와 `tracking` 필드가 없다. Codable은 모델에 없는 키를 조용히 무시하므로 decode는 성공한 것처럼 보이지만, 웹이 보낸 검색어와 추적 정보가 사라진 채 서버로 전송된다.

둘째, order item의 `quantity`가 iOS 모델에서만 필수 `Int`다. 웹과 서버 스키마에서는 optional이고 서버 기본값이 1이라 웹이 quantity를 생략할 수 있는데, 그 순간 iOS에서는 decode가 통째로 실패한다. 브릿지는 이 실패를 `try?`로 삼킨 뒤 속성이 텅 빈 이벤트를 정상처럼 전송한다.

이 경로로 실제 고객사의 iOS 앱에서 검색 이벤트의 search_query가 수개월간 유실돼 왔음을 확인했다. 조사 상세는 [BLX-865](https://app.notion.com/p/BLX-865-iOS-SDK-Web-4-98k-39c7a8baf188814f8f32ef14ececce5f).

## 수정

- `EventTracking` public struct를 신설하고 `EventProperties`에 `searchQuery`("search_query")와 `tracking` optional 필드를 추가했다. 웹이 보내는 값이 그대로 보존된다.
- `AddOrderEvent.Item`에 custom Codable을 구현해, 생략된 `quantity`를 서버와 동일하게 1로 decode한다. 네이티브 빌더와 public API는 변화 없다.
- decode 실패 처리를 바꿨다. 기존에는 실패를 삼키고 빈 속성 이벤트를 보냈지만, 이제 해당 request만 제외하고 같은 batch의 나머지 valid request는 유지한다. 의미가 달라진 이벤트를 정상처럼 보내는 것보다 명시적으로 보내지 않는 쪽이 안전하다. 로그에는 request index와 event type만 남기고 payload는 기록하지 않는다.

optional 필드 추가라 RN/Flutter wrapper 릴리스는 필요 없다.

# Tests you conducted

- [x] 전체 테스트 448건 통과 (클린 디렉토리 + iOS 26 시뮬레이터, 리뷰어 재실행 검증)
- [x] 신규 회귀 테스트 5건 — search_query/tracking 보존, quantity 생략 시 기본값 1, malformed 속성 이벤트 미전송, 혼합 batch에서 valid request 유지, built-in 키셋 계약 스냅샷을 각각 고정한다.
- [x] CI: 전체 단위 테스트 + stg pod lib lint 통과
