### PR TITLE
fix: Web 사용자 속성의 명시적 null을 보존

### DIFF
--- a/BluxClient/Classes/BluxWebSdkBridge.swift
+++ b/BluxClient/Classes/BluxWebSdkBridge.swift
@@ -138,13 +138,7 @@ private extension BluxWebSdkBridge {
             return
         }
 
-        do {
-            let data = try JSONSerialization.data(withJSONObject: dict)
-            let userProperties = try JSONDecoder().decode(UserProperties.self, from: data)
-            BluxClient.setUserProperties(userProperties: userProperties)
-        } catch {
-            Logger.error("BluxWebSdkBridge.setUserProperties: \(error)")
-        }
+        BluxClient.setUserPropertiesData(userProperties: dict)
     }
 
     func handleSetCustomUserProperties(_ payload: Any?) {
@@ -153,16 +147,7 @@ private extension BluxWebSdkBridge {
             return
         }
 
-        var sanitized: [String: Any?] = [:]
-        for (key, value) in dict {
-            if value is NSNull {
-                sanitized[key] = nil
-            } else {
-                sanitized[key] = value
-            }
-        }
-
-        BluxClient.setCustomUserProperties(customUserProperties: sanitized)
+        BluxClient.setCustomUserProperties(customUserProperties: dict)
     }
 
     func handleSendEvent(_ payload: Any?) {

--- a/Tests/BluxClientTests/BluxWebSdkBridgeTests.swift
+++ b/Tests/BluxClientTests/BluxWebSdkBridgeTests.swift
@@ -1,6 +1,75 @@
 import XCTest
 @testable import BluxClient
 
+private final class UpdatePropertiesURLProtocol: URLProtocol {
+    private static let lock = NSLock()
+    private static var capturedBodyStorage: Data?
+    private static var requestExpectation: XCTestExpectation?
+
+    static func reset(expectation: XCTestExpectation? = nil) {
+        lock.lock()
+        capturedBodyStorage = nil
+        requestExpectation = expectation
+        lock.unlock()
+    }
+
+    static var capturedBody: Data? {
+        lock.lock()
+        defer { lock.unlock() }
+        return capturedBodyStorage
+    }
+
+    override class func canInit(with request: URLRequest) -> Bool {
+        request.url?.host == "localhost"
+            && request.url?.path.contains("/update-properties") == true
+    }
+
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+        request
+    }
+
+    override func startLoading() {
+        let body = Self.readBody(from: request)
+
+        Self.lock.lock()
+        Self.capturedBodyStorage = body
+        let expectation = Self.requestExpectation
+        Self.lock.unlock()
+
+        let response = HTTPURLResponse(
+            url: request.url!,
+            statusCode: 200,
+            httpVersion: nil,
+            headerFields: ["Content-Type": "application/json"]
+        )!
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        client?.urlProtocol(self, didLoad: Data("{}".utf8))
+        client?.urlProtocolDidFinishLoading(self)
+        expectation?.fulfill()
+    }
+
+    override func stopLoading() {}
+
+    private static func readBody(from request: URLRequest) -> Data? {
+        if let body = request.httpBody {
+            return body
+        }
+
+        guard let stream = request.httpBodyStream else { return nil }
+        stream.open()
+        defer { stream.close() }
+
+        var data = Data()
+        var buffer = [UInt8](repeating: 0, count: 1_024)
+        while true {
+            let count = stream.read(&buffer, maxLength: buffer.count)
+            guard count >= 0 else { return nil }
+            guard count > 0 else { return data }
+            data.append(contentsOf: buffer.prefix(count))
+        }
+    }
+}
+
 /// Web SDK(`@blux.ai/sdk-web`)의 `IosBridge`가 보내는 메시지를 iOS SDK가 정확히 처리하는지 검증.
 ///
 /// Web SDK가 보내는 형태(IosBridge.postMessage):
@@ -17,15 +86,24 @@ import XCTest
 final class BluxWebSdkBridgeTests: XCTestCase {
     private var guardian: SdkStateGuard!
     private var bridge: BluxWebSdkBridge!
+    private var originalStage: Stage!
 
     override func setUp() {
         super.setUp()
+        originalStage = Stage.current
         guardian = SdkStateGuard()
         guardian.clear()
+        HTTPClient.shared.setStage(.local)
+        UpdatePropertiesURLProtocol.reset()
+        XCTAssertTrue(URLProtocol.registerClass(UpdatePropertiesURLProtocol.self))
         bridge = BluxWebSdkBridge()
     }
 
     override func tearDown() {
+        URLProtocol.unregisterClass(UpdatePropertiesURLProtocol.self)
+        UpdatePropertiesURLProtocol.reset()
+        HTTPClient.shared.setStage(originalStage)
+        originalStage = nil
         guardian.restore()
         guardian = nil
         bridge = nil
@@ -209,7 +287,8 @@ final class BluxWebSdkBridgeTests: XCTestCase {
             ]
         ]
         bridge.handle(scriptMessageBody: body)
-        // 사이드이펙트 직접 검증 어려움. 디코딩 자체가 throw 안 하면 통과 (BluxClient는 IDs 없으니 early return)
+        // BluxClient IDs가 없어 direct setter가 early return한다. Bridge가 dictionary를
+        // 그대로 허용하고 크래시 없이 dispatch하는지만 검증한다.
     }
 
     func testSetUserPropertiesNonDictionaryIsNoop() {
@@ -220,13 +299,76 @@ final class BluxWebSdkBridgeTests: XCTestCase {
         bridge.handle(scriptMessageBody: "{\"action\":\"setUserProperties\"}")
     }
 
-    func testSetUserPropertiesInvalidSchemaIsNoop() {
-        // age는 Int여야 함. String이면 디코딩 실패하지만 bridge는 swallow
-        let body: [String: Any] = [
-            "action": "setUserProperties",
-            "payload": ["age": "not-a-number"]
-        ]
-        bridge.handle(scriptMessageBody: body)
+    func testSetUserPropertiesPreservesExplicitNullInRequestBody() throws {
+        let requestBody = try captureUpdatePropertiesBody {
+            bridge.handle(
+                scriptMessageBody: #"{"action":"setUserProperties","payload":{"phone_number":null}}"#
+            )
+        }
+
+        let properties = try XCTUnwrap(requestBody["user_properties"] as? [String: Any])
+        XCTAssertTrue(properties.keys.contains("phone_number"))
+        XCTAssertTrue(properties["phone_number"] is NSNull)
+    }
+
+    func testSetUserPropertiesDataDistinguishesSwiftNilAndExplicitNull() throws {
+        let requestBody = try captureUpdatePropertiesBody {
+            let properties: [String: Any?] = [
+                "email_address": nil,
+                "phone_number": NSNull()
+            ]
+            BluxClient.setUserPropertiesData(userProperties: properties)
+        }
+
+        let properties = try XCTUnwrap(requestBody["user_properties"] as? [String: Any])
+        XCTAssertFalse(properties.keys.contains("email_address"))
+        XCTAssertTrue(properties.keys.contains("phone_number"))
+        XCTAssertTrue(properties["phone_number"] is NSNull)
+    }
+
+    func testSetCustomUserPropertiesPreservesExplicitNullInRequestBody() throws {
+        let requestBody = try captureUpdatePropertiesBody {
+            bridge.handle(
+                scriptMessageBody: #"{"action":"setCustomUserProperties","payload":{"removed_key":null}}"#
+            )
+        }
+
+        let properties = try XCTUnwrap(requestBody["custom_user_properties"] as? [String: Any])
+        XCTAssertTrue(properties.keys.contains("removed_key"))
+        XCTAssertTrue(properties["removed_key"] is NSNull)
+    }
+
+    func testSetCustomUserPropertiesEncodesSwiftNilAndExplicitNull() throws {
+        let requestBody = try captureUpdatePropertiesBody {
+            let properties: [String: Any?] = [
+                "swift_nil": nil,
+                "foundation_null": NSNull()
+            ]
+            BluxClient.setCustomUserProperties(customUserProperties: properties)
+        }
+
+        let properties = try XCTUnwrap(requestBody["custom_user_properties"] as? [String: Any])
+        XCTAssertTrue(properties.keys.contains("swift_nil"))
+        XCTAssertTrue(properties["swift_nil"] is NSNull)
+        XCTAssertTrue(properties.keys.contains("foundation_null"))
+        XCTAssertTrue(properties["foundation_null"] is NSNull)
+    }
+
+    private func captureUpdatePropertiesBody(
+        action: () -> Void
+    ) throws -> [String: Any] {
+        SdkConfig.clientIdInUserDefaults = "test-client-id"
+        SdkConfig.bluxIdInUserDefaults = "test-blux-id"
+
+        let requestCaptured = expectation(description: "update-properties request captured")
+        UpdatePropertiesURLProtocol.reset(expectation: requestCaptured)
+        action()
+        wait(for: [requestCaptured], timeout: 2)
+
+        let data = try XCTUnwrap(UpdatePropertiesURLProtocol.capturedBody)
+        return try XCTUnwrap(
+            JSONSerialization.jsonObject(with: data) as? [String: Any]
+        )
     }
 
     // MARK: - setCustomUserProperties
@@ -239,15 +381,6 @@ final class BluxWebSdkBridgeTests: XCTestCase {
                 "loyalty_points": 100,
                 "tags": ["a", "b"]
             ]
-        ]
-        bridge.handle(scriptMessageBody: body)
-    }
-
-    func testSetCustomUserPropertiesSanitizesNSNullToNil() {
-        // Web SDK에서 null로 보낸 값이 NSNull로 변환되는데 bridge가 nil로 처리해야 함
-        let body: [String: Any] = [
-            "action": "setCustomUserProperties",
-            "payload": ["removed_key": NSNull()]
         ]
         bridge.handle(scriptMessageBody: body)
     }


### PR DESCRIPTION
# 📝 Changes

## 문제

서버 계약(`bluxUsersUpdateProperties`)에서 사용자 속성 값 `null`은 "해당 속성 삭제", 키 생략은 "변경 없음"이다. WebView 브릿지가 이 구분을 두 경로 모두에서 파괴해, Web SDK가 보낸 삭제 요청(명시적 null)이 조용히 no-op이 됐다.

built-in 경로는 payload를 `UserProperties`(Codable)로 디코드하는데, 이 왕복에서 JSON `null`과 키 부재가 모두 Swift `nil`로 붕괴해 이후 변환에서 키가 body에서 사라진다.

custom 경로는 sanitize 루프가 `sanitized[key] = nil`을 대입한다. Swift dictionary에서 subscript에 nil을 대입하는 것은 값 저장이 아니라 **키 삭제**다. NSNull을 보존하려던 코드가 정반대로 동작했다.

결과적으로 웹뷰에서 전화번호·이메일·마케팅 동의·custom 속성을 지워도 서버에 예전 값이 그대로 남는다.

## 수정

정답 경로는 이미 있었다. `CustomValue.fromAny`가 NSNull을 `.null`로 처리하고, 서버 스키마는 전 필드 nullable이다. 브릿지가 그 앞에서 정보를 파괴하지 않도록 두 핸들러에서 디코드 왕복과 sanitize 루프를 삭제하고, dict를 기존 직접 API(`setUserPropertiesData` / `setCustomUserProperties`)에 그대로 전달한다. 프로덕션 변경은 +2/−17 순삭제이고, typed setter와 RN/Flutter wrapper가 쓰는 직접 API 경로는 건드리지 않았다.

## 계약 확정

이 PR에서 다음을 호환성 계약으로 확정하고 테스트로 고정한다 (직접 API의 기존 동작은 변경하지 않음):

| 입력 | wire 결과 |
|---|---|
| built-in 직접 API의 Swift nil | 키 생략 (변경 없음) |
| built-in 직접 API의 NSNull | 명시적 null (서버가 속성 삭제) |
| custom 직접 API의 Swift nil / NSNull | 둘 다 명시적 null |
| **Web 브릿지의 JSON null (built-in/custom)** | **명시적 null — 이 PR로 복구** |

## 행동 변경

- Web 브릿지의 명시적 null이 이제 서버로 전달되어 속성 삭제가 실제로 동작한다 (기존: 조용한 no-op).
- built-in의 알려진 키에 잘못된 타입이 오면, 기존에는 로컬 디코드 실패로 전체 요청이 조용히 중단됐지만 이제 서버 400으로 거절된다. 저장 결과는 동일하게 "무변화"다.

# Tests you conducted

- [x] fail-before 실증: main 프로덕션 코드에 이 브랜치의 테스트를 얹어 실행해, 신규 브릿지 테스트가 실제로 실패하는 것을 확인했다. 버그를 진짜로 잡는 회귀 테스트임을 입증한 것이다.
- [x] 전체 테스트 440건 통과 (클린 디렉토리 + iOS 26 시뮬레이터, 리뷰어 재실행 검증)
- [x] 신규 테스트 4건 — 테스트 전용 URLProtocol로 최종 HTTP body를 캡처해, 브릿지 경로 2개와 직접 API 계약(위 표)을 wire 레벨에서 assert한다.
- [x] 버그 동작을 명세하고 있던 무검증 테스트 2건 삭제
- [x] CI: 전체 단위 테스트 + stg pod lib lint 통과
