### PR TITLE
fix: 배너 창이 key window를 탈취하지 않도록 수정

### DIFF
--- a/BluxClient/Classes/BannerWindow.swift
+++ b/BluxClient/Classes/BannerWindow.swift
@@ -112,7 +112,6 @@ final class BannerWindow: UIWindow {
             frame = newFrame
             alpha = 0
             isHidden = false
-            makeKeyAndVisible()
             
             UIView.animate(withDuration: 0.2) {
                 self.alpha = 1
@@ -138,7 +137,6 @@ final class BannerWindow: UIWindow {
             frame = newFrame
             alpha = 0
             isHidden = false
-            makeKeyAndVisible()
 
             UIView.animate(withDuration: 0.2) {
                 self.alpha = 1
@@ -229,7 +227,6 @@ final class BannerWindow: UIWindow {
             self.webView.stopLoading()
             self.webView.configuration.userContentController.removeScriptMessageHandler(forName: "NativeiOSInterface")
             self.isHidden = true
-            self.resignKey()
             completion?()
         }
     }


### PR DESCRIPTION
# 📝 Changes

## 문제

배너의 두 표시 경로(top/bottom, absolute-position)가 `makeKeyAndVisible()`을 호출해 SDK 배너 윈도우가 호스트 앱의 key window를 탈취했다. 배너가 떠 있는 동안 호스트의 first responder가 해제돼 입력 중이던 키보드와 커서가 죽고, `isKeyWindow`로 윈도우를 찾는 코드(호스트 앱의 관용 코드와 SDK 내부의 인앱 모달 표시·푸시 탭 내비게이션)가 배너의 빈 rootViewController를 잡을 수 있었다.

## 수정

`BannerWindow.swift` 3줄 순삭제. 표시 경로 2곳의 `makeKeyAndVisible()`과 dismiss의 `resignKey()`를 삭제했다.

삭제가 안전한 이유: 두 표시 경로 모두 삭제 지점 바로 위에 `isHidden = false`가 이미 있다. `makeKeyAndVisible()`은 "key 승격 + 표시"인데 표시는 처음부터 `isHidden`이 담당했으므로, 사라지는 것은 key 탈취뿐이다. 이 호출은 배너 기능 최초 도입 커밋부터 있던 보일러플레이트로, 어떤 문제를 고치려고 추가된 이력이 없다. `resignKey()`는 key 승격이 없어지면 resign할 대상도 없다.

## 행동 변경

- 배너 표시 중에도 호스트 윈도우가 key를 유지한다 (이 PR의 목적).
- 배너 터치는 영향 없다. hit-testing은 visible 상태와 windowLevel 기준이고, 윈도우 frame이 배너 크기라 바깥 터치가 호스트로 통과하는 기존 설계 그대로다.
- 이론적 잔존 1건: 배너 HTML 안에 텍스트 입력이 있다면 non-key 윈도우에서는 키보드가 뜨지 않을 수 있다. 현재 배너 메시지 계약은 resize/link/dismiss뿐이라 입력 폼은 지원 대상이 아니었고, 지원 기능의 회귀가 아니다.

# Tests you conducted

- [x] 전체 테스트 443건 통과 (클린 디렉토리 + iOS 26 시뮬레이터, 리뷰어 재실행 검증)
- [x] 기존 `BannerWindowTests` 통과 — 단, 이는 frame 계산 무회귀만 보증한다. 이 버그의 증상(호스트 키보드/커서 탈취)은 단위 테스트로 잡을 수 없어 아래 수동 QA가 실질 검증이다.
- [x] CI: 전체 단위 테스트 + stg pod lib lint 통과

# ⛑ QA Test Cases

수행 환경: **iPhone 16 시뮬레이터, iOS 26.0** (Example 앱 + 내부 `BannerWindow`를 직접 구동하는 QA 하니스, 미커밋). 화면에 host window isKey / banner isKey / textField isFirstResponder를 실시간 표시하는 상태 라벨을 두고 검증했다.

- [x] 1. host text field에 입력해 keyboard 표시
- [x] 2. top banner 표시
- [x] 3. host keyboard와 cursor 유지 — 배너 표시 중 `hostIsKey=TRUE / bannerIsKey=false / fieldFirstResponder=TRUE`, 키보드 화면 유지, 추가 타이핑도 정상 입력
- [x] 4. banner link tap 동작 — top/bottom/absolute 3종 모두 link 메시지가 네이티브 핸들러 도달
- [x] 5. banner 바깥 host control tap 정상 동작
- [x] 6. banner dismiss 후 host 입력 지속 (first responder·키보드 유지 상태에서 이어서 타이핑 성공)
- [x] 7. bottom banner에서 반복 — 통과. 참고: 키보드가 떠 있으면 bottom 배너가 키보드 뒤에 가려지는데, 이는 키보드 윈도우 레벨이 더 높아서 생기는 기존 동작으로 이 수정과 무관.
- [x] 8. absolute-position banner에서 반복 — 통과 (옵션 `{top,left,right,height}` frame 계산도 화면과 일치)
- [ ] 9. iPad multi-window — 미수행

**fail-before 재현**: 같은 하니스를 수정 전 코드(main)로 빌드해 실행하면, 키보드가 뜬 상태에서 top 배너를 표시하는 순간 `hostIsKey=false / bannerIsKey=TRUE`로 뒤집히고 **키보드가 화면에서 사라지며 이후 타이핑이 유실**된다 (필드는 first responder를 유지한 채 입력만 죽는 형태). 이 수정을 적용하면 같은 시나리오에서 키보드와 입력이 그대로 유지된다.

**관찰 (수정과 무관한 기존 iOS 동작)**: 호스트에 활성 first responder가 없을 때 배너 webview를 탭하면 WKWebView의 first responder 승격으로 배너 윈도우가 일시적으로 key가 된다. 호스트에 활성 first responder가 있으면 탭해도 뺏기지 않고, 배너 dismiss 시 key는 host로 자동 복귀한다.
