### PR TITLE
fix: WebViewController 순환 참조 해제로 WKWebView 누수 차단

### DIFF
--- a/BluxClient/Classes/WebViewController.swift
+++ b/BluxClient/Classes/WebViewController.swift
@@ -11,6 +11,8 @@ import UIKit
 final class WebViewController: UIViewController, WKNavigationDelegate,
     WKScriptMessageHandler
 {
+    private static let scriptHandlerName = "NativeiOSInterface"
+
     private var webView: WKWebView!
     private var content: Content
     private let messageHandler = WebViewMessageHandler()
@@ -66,11 +68,31 @@ final class WebViewController: UIViewController, WKNavigationDelegate,
         updateWebViewConstraints()
     }
 
+    /// 순환 참조 2개를 끊는다.
+    /// (1) userContentController가 self를 강하게 보유 (BannerWindow.dismiss와 동일 처리)
+    /// (2) messageHandler의 클로저들이 self를 캡처
+    /// 철거 후 재표시는 지원하지 않는다 — 호출부는 표시마다 VC를 새로 만든다.
+    func teardownWebView() {
+        webView.stopLoading()
+        webView.configuration.userContentController
+            .removeScriptMessageHandler(forName: Self.scriptHandlerName)
+        messageHandler.removeAllHandlers()
+    }
+
+    override func viewDidDisappear(_ animated: Bool) {
+        super.viewDidDisappear(animated)
+        // 다른 화면이 위에 덮인 경우가 아니라 "최종적으로 내려가는" 경우에만 철거한다.
+        guard isBeingDismissed || isMovingFromParent
+            || navigationController?.isBeingDismissed == true
+        else { return }
+        teardownWebView()
+    }
+
     override func loadView() {
         super.loadView()
 
         let userContentController = WKUserContentController()
-        userContentController.add(self, name: "NativeiOSInterface")
+        userContentController.add(self, name: Self.scriptHandlerName)
 
         let configuration = WKWebViewConfiguration()
         configuration.userContentController = userContentController
@@ -199,7 +221,7 @@ final class WebViewController: UIViewController, WKNavigationDelegate,
         didReceive message: WKScriptMessage
     ) {
         guard
-            message.name == "NativeiOSInterface",
+            message.name == Self.scriptHandlerName,
             let messageBody = message.body as? [String: Any]
         else { return }
 

--- a/BluxClient/Classes/WebViewMessageHandler.swift
+++ b/BluxClient/Classes/WebViewMessageHandler.swift
@@ -11,6 +11,10 @@ final class WebViewMessageHandler {
         handlers.removeValue(forKey: action)
     }
 
+    func removeAllHandlers() {
+        handlers.removeAll()
+    }
+
     func handleMessage(_ action: String, data: JSON) {
         if let handler = handlers[action] {
             handler(data)

--- a/Tests/BluxClientTests/WebViewControllerLeakTests.swift
+++ b/Tests/BluxClientTests/WebViewControllerLeakTests.swift
@@ -1,0 +1,27 @@
+import XCTest
+@testable import BluxClient
+
+final class WebViewControllerLeakTests: XCTestCase {
+    // teardownWebView가 두 순환(script handler의 self 보유, 핸들러 클로저의 self 캡처)을
+    // 끊는지만 보장한다. viewDidDisappear의 종료 판정은 수동 검증(Instruments) 대상.
+    func testTeardownBreaksBothRetainCycles() {
+        weak var weakVC: WebViewController?
+        autoreleasepool {
+            var vc: WebViewController? = WebViewController(
+                content: .htmlString(
+                    html: "<html></html>",
+                    baseURL: URL(string: "https://blux.ai")!
+                )
+            )
+            vc!.loadViewIfNeeded()
+            let captured = vc! // InappService 핸들러의 캡처 재현
+            vc!.addMessageHandler(for: "hide") { _ in _ = captured }
+
+            vc!.teardownWebView()
+
+            weakVC = vc
+            vc = nil
+        }
+        XCTAssertNil(weakVC, "철거 후 WebViewController는 해제되어야 한다")
+    }
+}


### PR DESCRIPTION
# 📝 Changes

## 문제

`WebViewController`(인앱 메시지 표시와 푸시/인앱 링크 랜딩의 내장 브라우저에 쓰이는 VC)가 화면에서 내려간 뒤에도 절대 해제되지 않았다. 원인은 순환 참조 2개다.

1. `WKUserContentController.add(self, name:)`이 VC를 강하게 보유한다 (Apple 문서화된 동작).
2. InappService가 등록하는 hide/link 등 핸들러 클로저가 VC를 강하게 캡처한 채, VC가 소유한 `messageHandler`에 저장된다.

둘 중 하나만 있어도 해제되지 않으므로 둘 다 끊어야 한다. `deinit`에서의 정리는 원리적으로 불가능하다 — 순환 때문에 deinit 자체가 영원히 불리지 않는다. 표시할 때마다 WebViewController와 WKWebView가 누적되므로, 반복 표시가 있는 장기 세션에서 메모리 사용량이 계속 증가한다.

## 수정

VC가 사라지는 경로가 여러 갈래(hide/link 핸들러, close 버튼, resize→배너 스왑, `dismissCurrentInApp`, nav 컨테이너 dismiss)라 경로마다 철거를 심으면 누락이 생긴다. 모든 경로가 반드시 통과하는 단일 지점인 `viewDidDisappear`에서, 최종 종료로 판정될 때만 `teardownWebView()`로 두 순환을 함께 끊는다.

- 최종 종료 판정 3조건: `isBeingDismissed`(모달 자신이 dismiss) / `isMovingFromParent`(부모 컨테이너에서 제거) / `navigationController?.isBeingDismissed`(내장 브라우저처럼 nav 컨테이너째 dismiss될 때 — 이 경우 child의 `isBeingDismissed`는 false라 이 조건이 필요하다). 다른 화면이 위에 덮이기만 한 경우는 3조건 모두 false라 철거하지 않는다.
- `teardownWebView()`: `stopLoading` → script message handler 제거 → 핸들러 dictionary 전체 제거(`WebViewMessageHandler.removeAllHandlers()` 신규).
- script handler 제거는 같은 레포의 `BannerWindow.dismiss()`가 이미 쓰는 패턴을 빠진 곳에 적용한 것이다.
- 철거 후 재표시는 지원하지 않는다 — 호출부는 표시마다 VC를 새로 만들며, 현 코드베이스에 재사용하는 곳이 없다.

## 행동 변경

유일한 변화는 지금까지 누수 덕에 살아있던 VC가 정상 해제되는 것이다. 해제된 VC를 참조하는 곳은 `InappService.currentWebViewController`(static weak — 자동 nil)뿐임을 전수 확인했다.

# Tests you conducted

- [x] 전체 테스트 446건 통과 (iOS 26 시뮬레이터)
- [x] 신규 `WebViewControllerLeakTests` — 두 순환을 재현한 뒤 `teardownWebView()`를 호출하면 autoreleasepool 종료 직후 즉시 해제된다. 이 테스트가 보장하는 것은 teardown이 두 순환을 끊는다는 것까지고, `viewDidDisappear`의 종료 판정은 아래 수동 QA가 담당한다 (비호스트 XCTest에서는 UIKit presentation lifecycle이 돌지 않는다).
- [x] fail-before 실증 (로컬 변형 테스트, 미커밋) — teardown 없이 같은 시나리오를 돌리면 실제로 누수되고, teardown 후 캡처 클로저만 재등록해도 누수된다. 즉 두 순환이 각각 실재하며 `removeAllHandlers()`가 필수임을 확인했다.

# ⛑ QA Test Cases

수행 환경: **iOS 26.0 시뮬레이터** (Example 앱 + 생성한 `WebViewController`를 weak로 추적해 생존 인스턴스 수를 화면에 표시하는 QA 하니스, 미커밋). 핸들러는 InappService와 동일하게 VC를 강하게 캡처해 두 순환을 그대로 재현했고, Instruments 대신 weak 추적으로 해제 여부를 판정했다.

- [x] 1. overFullScreen 인앱을 hide 메시지로 닫기 → 인스턴스 해제
- [x] 2. resize 메시지로 modal을 dismiss하고 `BannerWindow`로 전환 → 해제 (중앙 `dismissWebView` helper를 우회하는 경로)
- [x] 3. `UINavigationController`에 감싸인 내장 브라우저를 xmark로 닫기 → 해제. child의 `isBeingDismissed`는 false인 케이스라 `navigationController?.isBeingDismissed` 조건이 실제로 동작함을 검증
- [x] 4. (추가) 모달 위에 fullScreen VC를 덮었다 걷은 뒤 hide로 닫기 → 오버레이 왕복 중 조기 철거 오발동 없음 (복귀 후 hide 핸들러 정상 동작, 이후 해제)

**fail-before 재현**: 같은 하니스를 수정 전 코드(main)로 빌드해 같은 3개 시나리오를 수행하면 `created=3 alive=3` — 닫힌 VC가 전부 메모리에 남는다. 이 수정을 적용한 빌드에서는 `created=3 alive=0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U5bSdBA3iwSk3TQ3KYYf2a
