### PR TITLE
fix: 인앱 표시 실패 시 파이프라인 복구

### DIFF
--- a/BluxClient/Classes/InappService.swift
+++ b/BluxClient/Classes/InappService.swift
@@ -458,6 +458,13 @@ class InappService {
                 topController.present(
                     webviewController, animated: false, completion: nil
                 )
+            } else {
+                // 표시할 화면이 없으면 (백그라운드 launch, scene 미활성 등) 이 인앱은 버리고
+                // 플래그를 복구해 파이프라인을 살린다 — 위 숨김 인앱 경로와 동일한 복구 패턴.
+                Logger.verbose(
+                    "INAPP: No top view controller to present on. Dropping inapp \(inappId).")
+                isWebViewPresented = false
+                processWebViewQueue()
             }
         }
     }


### PR DESCRIPTION
# 📝 Changes

## 문제

인앱은 한 번에 하나만 표시되도록 `isWebViewPresented` 플래그로 직렬화된다. 그런데 표시 직전에 화면을 찾는 `if let topController = UIViewController.getTopViewController()`에 else가 없어서, 표시할 화면이 없는 순간(백그라운드 launch, scene 미활성)에 인앱이 도착하면 플래그가 true로 잠긴 채 아무도 풀지 못한다. 그 뒤로는 앱을 다시 열어도 프로세스가 종료될 때까지 모든 인앱이 표시되지 않는다. 크래시도 로그도 없어서 "인앱이 안 나온다"는 증상만 남는다.

이 상황은 실제로 일어날 수 있다. 백그라운드에서 앱이 깨어나 initialize가 돌면 SDK가 visit 이벤트를 보내는데, 백그라운드 launch에서는 `didEnterBackground`가 발화하지 않아 인앱 차단 가드(`canDispatch`)를 통과하고, visit 트리거 인앱이 응답에 실려 오면 정확히 이 분기에 도달한다. visit 트리거 인앱은 prod에 실재한다.

## 수정

else를 추가해 플래그를 복구하고 다음 큐를 처리한다 — 같은 함수의 숨김 인앱 경로가 이미 쓰는 복구 패턴 그대로다. 순추가 +7줄이고, 정상 표시 경로는 한 줄도 바뀌지 않는다.

표시하지 못한 인앱은 버린다. 나중에 보여주려고 보관하면 서버의 발송 판단(빈도캡, 트리거 시점)과 어긋난 시점에 표시된다. 버린 인앱이 다시 내려온다는 보장은 없지만(서버는 발송 시점에 이미 `sent`로 기록한다), 현재 코드도 이 인앱을 똑같이 유실시키고 있다. 이 수정의 목적은 그 한 건을 살리는 것이 아니라, 이후 모든 인앱까지 막히는 전역 고착을 없애는 것이다.

# Tests you conducted

- [x] 전체 테스트 446건 통과
- [x] 이 분기(topController nil)는 비호스트 XCTest에서 재현할 수 없어 아래 수동 QA가 실질 검증이다.

# ⛑ QA Test Cases

수행 환경: **iOS 26.0 시뮬레이터**. Example 앱에 플래그와 큐 상태를 화면에 표시하는 QA 하니스(미커밋)를 붙이고, `getTopViewController()`가 nil인 상태에서 인앱 2건을 밀어 넣어 수정 전후를 대조했다.

- [x] 1. 수정 전(main): 2건 모두 소멸하면서 플래그가 true로 잠기고 큐에 1건이 갇힌다. 이후 정상 화면 상태에서 인앱을 넣어도 표시되지 않고 큐만 쌓인다 — 전역 고착 재현.
- [x] 2. 수정 후: 같은 시나리오에서 2건이 차례로 버려지며 플래그가 풀리고 큐가 비워진다. 이후 인앱은 정상 표시된다 — 파이프라인 생존.
- [x] 3. 정상 경로 회귀: 표시 → 닫기 → 다음 건 표시를 여러 사이클 반복해 이상 없음.

참고: 시뮬레이터는 홈 이탈·타앱 전환·알림센터 어느 방법으로도 scene을 `foregroundActive`에서 바꾸지 않아 백그라운드 launch 자체는 재현할 수 없었다 (계측으로 확인). 대신 rootViewController 없는 window를 잠시 key로 만들어 `getTopViewController()`가 nil을 반환하는 같은 조건을 구성했다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U5bSdBA3iwSk3TQ3KYYf2a
